### PR TITLE
Fix: training timeout never fires when process hangs

### DIFF
--- a/tui/orchestrator.py
+++ b/tui/orchestrator.py
@@ -16,6 +16,7 @@ based on the detected or configured backend.
 
 import os
 import re
+import select
 import subprocess
 import sys
 import threading
@@ -724,6 +725,13 @@ class ExperimentOrchestrator:
                     self._proc.wait()
                     return None
 
+                # Use select() with 1s timeout so the deadline check above
+                # actually fires when the process hangs (e.g. stuck in eval
+                # compilation). Without this, read(1) blocks indefinitely and
+                # the timeout never triggers.
+                ready, _, _ = select.select([self._proc.stdout], [], [], 1.0)
+                if not ready:
+                    continue  # No data -- loop back to check deadline/stop
                 byte = self._proc.stdout.read(1)
                 if not byte:
                     break


### PR DESCRIPTION
## Problem

The byte-by-byte reader (`read(1)`) in `orchestrator.py` blocks indefinitely when the training process stops producing output. This happens when:

- Eval compilation hangs on Blackwell GPUs (torch.compile inductor bugs)
- The training subprocess enters a long compilation phase with no stdout
- Any process that writes to stdout then goes silent before exiting

The 10-minute deadline check at line 721 never executes because it only runs between successful `read(1)` calls. If no bytes arrive, the loop hangs forever.

## Fix

Use `select.select()` with a 1-second timeout before `read(1)`. When no data is available within 1 second, the loop continues back to check the deadline and stop event. This is a 3-line change to the read loop.

## Testing

Discovered and verified during overnight autoresearch runs on an RTX 5070 Ti (Blackwell SM 12.0). The eval subprocess would hang for 3+ hours with no output before this fix. After the fix, the 10-minute timeout fires correctly.

## Impact

- No behavioral change during normal operation (select returns immediately when data is available)
- Fixes a hang that requires manual Ctrl+C intervention during unattended runs