### PR TITLE
Fix: stop agent on billing/auth API errors instead of retrying

### DIFF
--- a/tui/orchestrator.py
+++ b/tui/orchestrator.py
@@ -644,6 +644,16 @@ class ExperimentOrchestrator:
                 err_str = str(e).lower()
                 err_type = type(e).__name__
 
+                # Fatal errors that will never recover -- stop immediately
+                if "credit balance" in err_str or "insufficient_quota" in err_str:
+                    self._cb_error(f"FATAL: API billing error -- stopping agent. {e}")
+                    self._stop_event.set()
+                    return None
+                if "authentication" in err_str and "401" in err_str:
+                    self._cb_error(f"FATAL: API authentication failed -- stopping agent. {e}")
+                    self._stop_event.set()
+                    return None
+
                 # Classify the error and determine backoff
                 if "rate" in err_str or "429" in err_str:
                     wait = min(60 * (2 ** attempt), 600)


### PR DESCRIPTION
## Problem

When the Anthropic API returns a billing error ('credit balance too low') or authentication failure, the backoff handler retries 5 times with exponential delays. These errors will never recover by retrying.

Observed behavior without this fix:
1. Agent runs overnight, credits deplete mid-run
2. Every subsequent API call returns 400 ('credit balance too low')
3. Agent retries each call 5x with backoff (wastes ~10 min per experiment)
4. Counts as failed experiment, moves to next one
5. Repeats until max_runs exhausted -- 54 experiment slots burned in ~3 min with zero useful work

## Fix

Detect fatal billing/auth errors before the retry classifier and set `stop_event` for a clean shutdown. Two patterns detected:

- `'credit balance'` in error string (Anthropic billing exhaustion)
- `'authentication'` + `'401'` (invalid/revoked API key)

## Impact

- No change to transient error handling (rate limits, 5xx, connection errors still retry normally)
- Agent stops cleanly on unrecoverable errors
- Prevents wasting experiment slots and GPU time on guaranteed-to-fail API calls