### PR TITLE
Add PMC Open Access full-text dataset (521K biomedical papers)

### DIFF
--- a/convert_dataset.py
+++ b/convert_dataset.py
@@ -128,6 +128,15 @@ DATASETS = {
         "min_score": None,
         "est_source_size_gb": 0.28,  # per file (~280 MB × 52 = ~14.6 GB total)
     },
+    "pmc-fulltext": {
+        "description": "PMC Open Access (Markdown): 521K full-text biomedical papers from PubMed Central (CC BY 4.0)",
+        "base_url": "https://huggingface.co/datasets/casperhansen/pmc-oa-markdown/resolve/refs%2Fconvert%2Fparquet/default/train",
+        "source_files": [f"{i:04d}.parquet" for i in range(49)],
+        "text_column": "text",
+        "extra_columns": [],
+        "min_score": None,
+        "est_source_size_gb": 0.35,  # per file (~350 MB × 49 = ~17 GB total)
+    },
     "slimpajama-627b": {
         "description": "SlimPajama-627B: full deduplicated RedPajama (627B tokens, 7 sources)",
         "base_url": "https://huggingface.co/datasets/gmongaras/SlimPajama-627B_Reupload/resolve/refs%2Fconvert%2Fparquet/default/train",

--- a/run_suite.py
+++ b/run_suite.py
@@ -65,6 +65,7 @@ DATASET_ORDER = [
     "fineweb",
     "github-code-python",
     "pubmed-abstract",
+    "pmc-fulltext",
     # "slimpajama-627b",  # 300 GB download — enable manually if desired
 ]
 


### PR DESCRIPTION
## Summary

Adds PMC Open Access full-text dataset support, complementing the existing `pubmed-abstract` dataset with complete biomedical papers.

- Adds `pmc-fulltext` config to `convert_dataset.py` DATASETS dict
- Adds `pmc-fulltext` to `run_suite.py` DATASET_ORDER (after pubmed-abstract)

## Dataset Details

| Field | Value |
|-------|-------|
| **Source** | [casperhansen/pmc-oa-markdown](https://huggingface.co/datasets/casperhansen/pmc-oa-markdown) |
| **Size** | 521K full-text papers, 49 parquet shards (~17 GB) |
| **Text column** | `text` (Markdown-formatted full papers) |
| **License** | CC BY 4.0 |
| **Content** | Full biomedical research papers from PubMed Central Open Access subset |

## Relationship to existing datasets

- `pubmed-abstract` (already in codebase): 27.7M short abstracts (~200 words each)
- `pmc-fulltext` (this PR): 521K full papers (~3,000-10,000 words each)

The two datasets test different aspects of language modeling — short dense scientific text vs long-form structured research with sections, figures, references.

## Test plan

- [ ] `python convert_dataset.py pmc-fulltext --num-shards 10` completes without error
- [ ] Tokenizer trains successfully on the converted shards
- [ ] `python -m tui.headless --max 2 --dataset pmc-fulltext` produces valid results

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)