### PR TITLE
Add validation retry with backoff, fix push upstream tracking

### DIFF
--- a/tui/orchestrator.py
+++ b/tui/orchestrator.py
@@ -265,18 +265,44 @@ class ExperimentOrchestrator:
                 self._cb_error(f"LLM backend error: {e}")
                 return
 
-            # Validate credentials with a preflight API call
+            # Validate credentials with a preflight API call (with retry).
+            # A single-shot validate() caused issue #9: a transient API 529
+            # during validation abandoned the entire dataset run.
             self._cb_status("initializing", "Validating API credentials...")
-            try:
-                if not self._llm.validate():
-                    source = getattr(self._llm, '_cred_source', 'unknown')
-                    self._cb_error(
-                        f"API credential validation failed (source: {source}). "
-                        f"Run: python dashboard.py --setup-key"
-                    )
-                    return
-            except Exception as e:
-                self._cb_error(f"API validation error: {e}")
+            validated = False
+            for attempt in range(5):
+                try:
+                    if self._llm.validate():
+                        validated = True
+                        break
+                    else:
+                        # validate() returned False — credentials are bad (not transient)
+                        source = getattr(self._llm, '_cred_source', 'unknown')
+                        self._cb_error(
+                            f"API credential validation failed (source: {source}). "
+                            f"Run: python dashboard.py --setup-key"
+                        )
+                        return
+                except Exception as e:
+                    err_str = str(e).lower()
+                    # Fatal auth/billing errors — don't retry
+                    if any(k in err_str for k in [
+                        "authentication", "401", "invalid_api_key",
+                        "credit balance", "insufficient_quota",
+                    ]):
+                        self._cb_error(f"API credential error (fatal): {e}")
+                        return
+                    # Transient errors (529, 5xx, connection) — retry with backoff
+                    wait = min(15 * (2 ** attempt), 120)
+                    self._cb_status("initializing",
+                        f"API validation error (attempt {attempt+1}/5, retrying in {wait}s): {e}")
+                    for _ in range(max(1, wait // 5)):
+                        if self._stop_event.is_set():
+                            return
+                        time.sleep(5)
+
+            if not validated:
+                self._cb_error("API validation failed after 5 attempts — aborting")
                 return
             self._cb_status("initializing", "API credentials validated")
 
@@ -668,9 +694,19 @@ class ExperimentOrchestrator:
                 except Exception:
                     pass
 
-            # Push (silently — don't block on network errors)
+            # Push to remote. Use `push -u` to set upstream tracking on
+            # the first push of a new branch — `push.autoSetupRemote=true`
+            # is unreliable across pod restarts and git checkouts.
             try:
-                self._git._run("push", check=False)
+                branch = self._git._run("rev-parse", "--abbrev-ref", "HEAD", check=False)
+                has_upstream = bool(self._git._run(
+                    "rev-parse", "--abbrev-ref", f"{branch}@{{u}}", check=False
+                ))
+                if has_upstream:
+                    self._git._run("push", check=False)
+                else:
+                    # First push — set upstream explicitly
+                    self._git._run("push", "-u", "origin", branch, check=False)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary

Two reliability fixes from issue #9 post-mortem that address the most impactful failure modes in long-running suite deployments.

### Fix 1: Validation retry with backoff

**Problem**: The `validate()` preflight call in `_run_loop()` was single-shot with no retry. A transient API 529 ("Overloaded") during validation abandoned the entire dataset run — this is exactly what caused FineWeb-Edu-High to be skipped during the RTX PRO 6000 v2 suite (issue #9, 0/80 experiments).

**Fix**: Retry up to 5 times with exponential backoff (15s → 30s → 60s → 120s). Fatal errors (401, invalid_api_key, insufficient_quota, credit balance) still fail immediately — only transient errors (529, 5xx, connection timeouts) trigger retry.

**Before**: One API blip → entire dataset abandoned
**After**: Tolerates up to ~5 minutes of API instability before giving up

### Fix 2: Explicit push upstream tracking

**Problem**: `_maybe_sync_results()` called bare `git push`, which silently fails on new branches without upstream tracking. Despite `push.autoSetupRemote=true` being configured, every RunPod deployment required manual `git push -u` to start syncing. This caused results to accumulate locally without reaching GitHub on both the RTX PRO 6000 and MI300X pods — discovered repeatedly across multiple sessions.

**Fix**: Before each push, check if the current branch has upstream tracking (`rev-parse --abbrev-ref @{u}`). If not, use `git push -u origin <branch>` explicitly. This eliminates the dependency on `push.autoSetupRemote` config being set correctly.

**Before**: New dataset branches silently fail to push until manual intervention
**After**: First sync after branch creation automatically sets up upstream

## Files Changed

- `tui/orchestrator.py` — validation retry loop (lines ~268-301), push upstream detection (lines ~672-683)

## Testing

1. **Validation retry**: Set `ANTHROPIC_API_KEY` to a valid key, kill network briefly during startup → should retry and succeed
2. **Fatal error fast-fail**: Set invalid API key → should fail immediately (no retry)
3. **Push upstream**: Create a new experiment branch, run one experiment → verify first sync creates upstream tracking without manual `git push -u`

## Related Issues

- Closes the "remaining fix needed" item from issue #9
- Addresses the "auto-push still fragile" observation from issue #9
- Prevents the class of failure that caused issue #13 (GitHub-Code-Python incomplete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)