### PR TITLE
Add OpenRouter backend for unified multi-model support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ agent-azure = [
     "textual>=3.0.0",
     "openai>=1.0.0",
 ]
+agent-openrouter = [
+    "textual>=3.0.0",
+    "openai>=1.0.0",  # OpenRouter uses OpenAI SDK with custom base_url
+]
 agent-all = [
     "textual>=3.0.0",
     "anthropic>=0.40.0",

--- a/run_suite.py
+++ b/run_suite.py
@@ -381,18 +381,25 @@ def _model_slug(model: str | None) -> str | None:
     Non-default models get results/<slug>/<dataset>/.
 
     Examples:
-        "claude-sonnet-4-20250514"  → None  (default)
-        "claude-opus-4-6"           → "opus-4-6"
-        "claude-haiku-4-5-20251001" → "haiku-4-5-20251001"
-        "gpt-4.1"                   → "gpt-4.1"
-        "gpt-5.1"                   → "gpt-5.1"
+        "claude-sonnet-4-20250514"          → None  (default)
+        "claude-opus-4-6"                   → "opus-4-6"
+        "claude-haiku-4-5-20251001"         → "haiku-4-5-20251001"
+        "gpt-4.1"                           → "gpt-4.1"
+        "gpt-5.1"                           → "gpt-5.1"
+        "anthropic/claude-sonnet-4.6"       → "claude-sonnet-4.6"  (OpenRouter)
+        "meta-llama/llama-4-maverick"       → "llama-4-maverick"   (OpenRouter)
+        "openai/gpt-4.1"                    → "gpt-4.1"            (OpenRouter)
     """
     if model is None or model == DEFAULT_MODEL:
         return None
+    slug = model
+    # OpenRouter uses provider/model format — strip the provider prefix
+    if "/" in slug:
+        slug = slug.split("/", 1)[1]
     # Strip common provider prefixes for shorter directory names
-    slug = model.removeprefix("claude-")
+    slug = slug.removeprefix("claude-")
     # Sanitize for filesystem safety
-    slug = slug.replace("/", "-").replace("\\", "-").replace(":", "-").strip("-")
+    slug = slug.replace("\\", "-").replace(":", "-").strip("-")
     return slug or None
 
 

--- a/tui/headless.py
+++ b/tui/headless.py
@@ -174,7 +174,7 @@ def main():
     parser.add_argument("--results", default="results.tsv", help="Results TSV path")
     parser.add_argument("--dataset", type=str, default="", help="Dataset name (for heartbeat/logging)")
     parser.add_argument("--model", type=str, default=None,
-                        help="Model override (e.g. 'claude-opus-4-6', 'gpt-4.1'). Provider auto-detected from API key env vars.")
+                        help="Model override (e.g. 'claude-opus-4-6', 'gpt-4.1', 'anthropic/claude-sonnet-4.6' for OpenRouter). Provider auto-detected from API key env vars.")
     args = parser.parse_args()
 
     # PID lock -- prevent duplicate experiment runs

--- a/tui/llm_backend.py
+++ b/tui/llm_backend.py
@@ -420,6 +420,93 @@ class AzureOpenAIBackend(LLMBackend):
 
 
 # ---------------------------------------------------------------------------
+# OpenRouter Backend
+# ---------------------------------------------------------------------------
+
+class OpenRouterBackend(LLMBackend):
+    """OpenRouter API backend — unified access to 200+ models via OpenAI-compatible API.
+
+    Uses the same openai SDK with a custom base_url. One API key provides
+    access to Claude, GPT, Gemini, Llama, Mistral, and more.
+
+    Env vars:
+        OPENROUTER_API_KEY: API key from openrouter.ai (required)
+        OPENROUTER_MODEL:   Model ID in provider/model format (default: anthropic/claude-sonnet-4.6)
+    """
+
+    DEFAULT_MODEL = "anthropic/claude-sonnet-4.6"
+
+    def __init__(self, model: str | None = None):
+        try:
+            from openai import OpenAI
+        except ImportError:
+            raise ImportError(
+                "openai package not installed. Run: pip install openai"
+            )
+
+        api_key = os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENROUTER_API_KEY environment variable not set")
+
+        self._client = OpenAI(
+            api_key=api_key,
+            base_url="https://openrouter.ai/api/v1",
+            default_headers={
+                "HTTP-Referer": "https://github.com/elementalcollision/autoresearch-unified",
+                "X-Title": "autoresearch-unified",
+            },
+        )
+        self._model = model or os.environ.get("OPENROUTER_MODEL") or self.DEFAULT_MODEL
+
+    def name(self) -> str:
+        return f"OpenRouter ({self._model})"
+
+    def validate(self) -> bool:
+        """Test the API key with a minimal request."""
+        try:
+            from openai import AuthenticationError
+            self._client.chat.completions.create(
+                model=self._model,
+                max_tokens=5,
+                messages=[{"role": "user", "content": "Say OK"}],
+            )
+            return True
+        except AuthenticationError:
+            return False
+
+    def generate_experiment(
+        self,
+        current_code: str,
+        results_history: str,
+        best_val_bpb: float,
+        best_experiment: str,
+        hw_info: dict,
+    ) -> ExperimentProposal:
+        user_prompt = USER_PROMPT_TEMPLATE.format(
+            current_code=current_code,
+            results_history=results_history if results_history else "No experiments yet -- this will be the first modification after baseline.",
+            chip_name=hw_info.get("chip_name", "Unknown"),
+            memory_gb=hw_info.get("memory_gb", 0),
+            gpu_cores=hw_info.get("gpu_cores", 0),
+            peak_tflops=hw_info.get("peak_tflops", 0),
+            best_val_bpb=best_val_bpb,
+            best_experiment=best_experiment,
+        )
+
+        response = self._client.chat.completions.create(
+            model=self._model,
+            max_tokens=2048,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+        )
+
+        response_text = response.choices[0].message.content
+        return parse_llm_response(response_text)
+
+
+# ---------------------------------------------------------------------------
 # Ollama Backend (placeholder)
 # ---------------------------------------------------------------------------
 
@@ -456,24 +543,30 @@ def get_llm_backend(model: str | None = None) -> LLMBackend:
 
     Priority:
     1. OLLAMA_MODEL env var -> OllamaBackend (local, placeholder)
-    2. AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT -> AzureOpenAIBackend
-    3. OPENAI_API_KEY -> OpenAIBackend
-    4. Anthropic credentials (env/keychain/file) -> ClaudeBackend
-    5. Error with setup instructions for all providers
+    2. OPENROUTER_API_KEY -> OpenRouterBackend (unified multi-model router)
+    3. AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT -> AzureOpenAIBackend
+    4. OPENAI_API_KEY -> OpenAIBackend
+    5. Anthropic credentials (env/keychain/file) -> ClaudeBackend
+    6. Error with setup instructions for all providers
     """
     # 1. Ollama (local)
     if os.environ.get("OLLAMA_MODEL"):
         return OllamaBackend()
 
-    # 2. Azure OpenAI (check before OpenAI — more specific env vars)
+    # 2. OpenRouter (unified router — before direct providers because if
+    # someone sets OPENROUTER_API_KEY, they want traffic routed through it)
+    if os.environ.get("OPENROUTER_API_KEY"):
+        return OpenRouterBackend(model=model)
+
+    # 3. Azure OpenAI (check before OpenAI — more specific env vars)
     if os.environ.get("AZURE_OPENAI_API_KEY") and os.environ.get("AZURE_OPENAI_ENDPOINT"):
         return AzureOpenAIBackend(model=model)
 
-    # 3. OpenAI
+    # 4. OpenAI
     if os.environ.get("OPENAI_API_KEY"):
         return OpenAIBackend(model=model)
 
-    # 4. Anthropic Claude (default)
+    # 5. Anthropic Claude (default)
     try:
         return ClaudeBackend(model=model)
     except (RuntimeError, ImportError):
@@ -484,6 +577,10 @@ def get_llm_backend(model: str | None = None) -> LLMBackend:
         "\n"
         "  Anthropic Claude (recommended):\n"
         "    export ANTHROPIC_API_KEY=sk-ant-...\n"
+        "\n"
+        "  OpenRouter (200+ models, one API key):\n"
+        "    export OPENROUTER_API_KEY=sk-or-...\n"
+        "    export OPENROUTER_MODEL=anthropic/claude-sonnet-4.6  # optional\n"
         "\n"
         "  OpenAI:\n"
         "    export OPENAI_API_KEY=sk-...\n"

--- a/tui/orchestrator.py
+++ b/tui/orchestrator.py
@@ -760,6 +760,10 @@ class ExperimentOrchestrator:
                     self._cb_error(f"FATAL: Azure deployment not found -- stopping agent. {e}")
                     self._stop_event.set()
                     return None
+                if "model_not_found" in err_str or "insufficient_credits" in err_str or "payment_required" in err_str:
+                    self._cb_error(f"FATAL: OpenRouter error -- stopping agent. {e}")
+                    self._stop_event.set()
+                    return None
 
                 # Classify the error and determine backoff
                 if "rate" in err_str or "429" in err_str:


### PR DESCRIPTION
## Summary

Adds OpenRouter as an LLM backend, providing access to 200+ models (Claude, GPT, Gemini, Llama, Mistral, etc.) through a single API key and one code path. Uses the existing `openai` SDK with a custom `base_url` — no new dependencies.

## Changes

| File | Change |
|------|--------|
| `tui/llm_backend.py` | `OpenRouterBackend` class (~85 lines) + factory update |
| `tui/orchestrator.py` | Fatal error detection for `model_not_found`, `insufficient_credits`, `payment_required` |
| `pyproject.toml` | `agent-openrouter` dependency group |
| `tui/headless.py` | `--model` help text updated with OpenRouter examples |
| `run_suite.py` | `_model_slug()` handles `provider/model` format (e.g., `anthropic/claude-sonnet-4.6` → `sonnet-4.6`) |

## Factory Priority

1. `OLLAMA_MODEL` → OllamaBackend (local)
2. **`OPENROUTER_API_KEY` → OpenRouterBackend** ← NEW
3. `AZURE_OPENAI_API_KEY` + endpoint → AzureOpenAIBackend
4. `OPENAI_API_KEY` → OpenAIBackend
5. Anthropic credentials → ClaudeBackend

## Usage

```bash
# Default (Claude Sonnet via OpenRouter)
export OPENROUTER_API_KEY=sk-or-...
python -m tui.headless --max 5

# Specific model
export OPENROUTER_API_KEY=sk-or-...
python -m tui.headless --model openai/gpt-4.1 --max 5

# Cross-model comparison
python run_suite.py --model meta-llama/llama-4-maverick --dataset climbmix
# Results → results/llama-4-maverick/climbmix/results.tsv
```

## Verification

- `OpenRouterBackend` is a proper `LLMBackend` subclass ✅
- All abstract methods implemented ✅
- Factory detects `OPENROUTER_API_KEY` ✅
- `_model_slug()` handles `provider/model` format ✅
- Fatal error handling covers OpenRouter-specific errors ✅

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)