### PR TITLE
Fix blocking read(1) in TUI reader thread (#21)

### DIFF
--- a/tui/app.py
+++ b/tui/app.py
@@ -1,6 +1,7 @@
 """Main Textual Application for the autoresearch dashboard (AMD ROCm / MI300x)."""
 
 import os
+import select
 import subprocess
 import sys
 import threading
@@ -168,6 +169,9 @@ class DashboardApp(App):
         buffer = ""
         try:
             while True:
+                ready, _, _ = select.select([proc.stdout], [], [], 1.0)
+                if not ready:
+                    continue  # No data — loop back (daemon thread exits with app)
                 byte = proc.stdout.read(1)
                 if not byte:
                     break


### PR DESCRIPTION
## Summary
- Apply `select.select()` timeout guard to `tui/app.py:_reader_worker`, matching the orchestrator fix from PR #1
- Prevents TUI freeze when training subprocess hangs (e.g. Blackwell eval compilation)
- 3-line change: add `import select`, wrap `read(1)` with 1-second `select.select()` timeout

Closes #21

## Test plan
- [x] All 107 tests pass, no regressions
- [x] Verified the fix matches the proven pattern in `tui/orchestrator.py:854-861`

🤖 Generated with [Claude Code](https://claude.com/claude-code)