### PR TITLE
Reorganize GitHub Pages into hub with leaderboard and course

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Autonomous LLM-driven GPU pretraining research -- unified across NVIDIA, AMD, Intel, and Apple platforms.
 
-> **[Take the Interactive Course](https://elementalcollision.github.io/autoresearch-unified/)** — Learn how this entire codebase works through animated diagrams, code walkthroughs, and interactive quizzes. No CS background needed.
+> **[Take the Interactive Course](https://elementalcollision.github.io/autoresearch-unified/course/)** — Learn how this entire codebase works through animated diagrams, code walkthroughs, and interactive quizzes. No CS background needed.
 
 ## What Is This?
 
@@ -154,7 +154,7 @@ df = ds["train"].to_pandas()
 
 ## Documentation
 
-**[Interactive Course](https://elementalcollision.github.io/autoresearch-unified/)** — A visual, scroll-based walkthrough of the entire codebase with animated data flows, code-to-English translations, and quizzes. Great for onboarding or understanding the architecture.
+**[Interactive Course](https://elementalcollision.github.io/autoresearch-unified/course/)** — A visual, scroll-based walkthrough of the entire codebase with animated data flows, code-to-English translations, and quizzes. Great for onboarding or understanding the architecture.
 
 See the [wiki](https://github.com/elementalcollision/autoresearch-unified/wiki) for:
 - [Cross-Platform Overview](https://github.com/elementalcollision/autoresearch-unified/wiki/Cross-Platform-Overview) -- Key findings and normalized comparisons

--- a/docs/benchmark/index.html
+++ b/docs/benchmark/index.html
@@ -4,6 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Autoresearch Benchmark &mdash; LLM Autonomous ML Researcher Leaderboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../shared.css">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 <style>
 /* ============================================================
@@ -42,6 +46,7 @@ body {
   color: var(--text);
   line-height: 1.5;
   min-height: 100vh;
+  padding-top: 50px;
 }
 
 a { color: var(--accent); text-decoration: none; }
@@ -405,6 +410,16 @@ footer {
 </style>
 </head>
 <body>
+
+<!-- Site Nav -->
+<nav class="site-nav" role="navigation" aria-label="Site navigation">
+  <a href="../" class="site-nav-brand">autoresearch</a>
+  <ul class="site-nav-links">
+    <li><a href="./" class="active">Benchmark</a></li>
+    <li><a href="../course/">Course</a></li>
+    <li><a href="https://github.com/elementalcollision/autoresearch-unified" target="_blank">GitHub</a></li>
+  </ul>
+</nav>
 
 <div class="container">
   <header>
@@ -806,6 +821,12 @@ document.querySelectorAll('thead th[data-key]').forEach(th => {
 // ============================================================
 loadData();
 </script>
+
+<footer class="site-footer">
+  <a href="https://github.com/elementalcollision/autoresearch-unified">GitHub</a>
+  <a href="https://huggingface.co/datasets/davegraham/autoresearch-experiments">HuggingFace</a>
+  <a href="https://github.com/elementalcollision/autoresearch-unified/wiki">Wiki</a>
+</footer>
 
 </body>
 </html>

--- a/docs/course/index.html
+++ b/docs/course/index.html
@@ -1,0 +1,1455 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>How Autoresearch Works — An Interactive Course</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400;1,9..40,500&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../shared.css">
+<style>
+/* ============================================================
+   DESIGN SYSTEM
+   ============================================================ */
+:root {
+  --color-bg:             #FAF7F2;
+  --color-bg-warm:        #F5F0E8;
+  --color-bg-code:        #1E1E2E;
+  --color-text:           #2C2A28;
+  --color-text-secondary: #6B6560;
+  --color-text-muted:     #9E9790;
+  --color-border:         #E5DFD6;
+  --color-border-light:   #EEEBE5;
+  --color-surface:        #FFFFFF;
+  --color-surface-warm:   #FDF9F3;
+  --color-accent:         #D94F30;
+  --color-accent-hover:   #C4432A;
+  --color-accent-light:   #FDEEE9;
+  --color-accent-muted:   #E8836C;
+  --color-success:        #2D8B55;
+  --color-success-light:  #E8F5EE;
+  --color-error:          #C93B3B;
+  --color-error-light:    #FDE8E8;
+  --color-info:           #2A7B9B;
+  --color-info-light:     #E4F2F7;
+  --color-actor-1:        #D94F30;
+  --color-actor-2:        #2A7B9B;
+  --color-actor-3:        #7B6DAA;
+  --color-actor-4:        #D4A843;
+  --color-actor-5:        #2D8B55;
+  --font-display:  'Bricolage Grotesque', Georgia, serif;
+  --font-body:     'DM Sans', -apple-system, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+  --text-xs:   0.75rem;
+  --text-sm:   0.875rem;
+  --text-base: 1rem;
+  --text-lg:   1.125rem;
+  --text-xl:   1.25rem;
+  --text-2xl:  1.5rem;
+  --text-3xl:  1.875rem;
+  --text-4xl:  2.25rem;
+  --text-5xl:  3rem;
+  --text-6xl:  3.75rem;
+  --leading-tight:  1.15;
+  --leading-snug:   1.3;
+  --leading-normal: 1.6;
+  --leading-loose:  1.8;
+  --space-1:  0.25rem;
+  --space-2:  0.5rem;
+  --space-3:  0.75rem;
+  --space-4:  1rem;
+  --space-5:  1.25rem;
+  --space-6:  1.5rem;
+  --space-8:  2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+  --space-20: 5rem;
+  --space-24: 6rem;
+  --content-width:     800px;
+  --content-width-wide: 1000px;
+  --nav-height:        50px;
+  --radius-sm:  8px;
+  --radius-md:  12px;
+  --radius-lg:  16px;
+  --radius-full: 9999px;
+  --shadow-sm:  0 1px 2px rgba(44,42,40,0.05);
+  --shadow-md:  0 4px 12px rgba(44,42,40,0.08);
+  --shadow-lg:  0 8px 24px rgba(44,42,40,0.1);
+  --shadow-xl:  0 16px 48px rgba(44,42,40,0.12);
+  --ease-out:    cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --duration-fast:   150ms;
+  --duration-normal: 300ms;
+  --duration-slow:   500ms;
+  --stagger-delay:   120ms;
+}
+
+/* ============================================================
+   RESET & BASE
+   ============================================================ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-snap-type: y proximity; scroll-behavior: smooth; }
+body {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--color-text);
+  background: var(--color-bg);
+  background-image: radial-gradient(ellipse at 20% 50%, rgba(217,79,48,0.03) 0%, transparent 50%);
+  -webkit-font-smoothing: antialiased;
+}
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: var(--radius-full); }
+pre, code { white-space: pre-wrap; word-break: break-word; overflow-x: hidden; }
+a { color: var(--color-accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ============================================================
+   NAV
+   ============================================================ */
+.nav {
+  position: fixed; top: 50px; left: 0; right: 0; z-index: 1000;
+  background: rgba(250,247,242,0.92); backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--color-border-light);
+  height: var(--nav-height);
+}
+.progress-bar {
+  position: absolute; top: 0; left: 0; height: 3px;
+  background: var(--color-accent); width: 0%; transition: width 100ms linear;
+}
+.nav-inner {
+  max-width: var(--content-width-wide); margin: 0 auto;
+  display: flex; align-items: center; justify-content: space-between;
+  height: 100%; padding: 0 var(--space-6);
+}
+.nav-title { font-family: var(--font-display); font-weight: 700; font-size: var(--text-sm); color: var(--color-text); }
+.nav-dots { display: flex; gap: var(--space-3); }
+.nav-dot {
+  width: 12px; height: 12px; border-radius: 50%;
+  border: 2px solid var(--color-text-muted); background: transparent;
+  cursor: pointer; transition: all var(--duration-fast);
+  position: relative; padding: 0;
+}
+.nav-dot:hover { border-color: var(--color-accent); }
+.nav-dot.active { border-color: var(--color-accent); background: var(--color-accent); box-shadow: 0 0 8px rgba(217,79,48,0.3); }
+.nav-dot.visited { background: var(--color-accent); border-color: var(--color-accent); }
+.nav-dot[data-tooltip]:hover::after {
+  content: attr(data-tooltip); position: absolute; top: calc(100% + 8px); left: 50%;
+  transform: translateX(-50%); background: var(--color-bg-code); color: #CDD6F4;
+  padding: var(--space-1) var(--space-3); border-radius: var(--radius-sm);
+  font-size: var(--text-xs); white-space: nowrap; pointer-events: none; z-index: 1001;
+}
+
+/* ============================================================
+   MODULE LAYOUT
+   ============================================================ */
+.module {
+  min-height: 100dvh; min-height: 100vh;
+  scroll-snap-align: start;
+  padding: var(--space-16) var(--space-6);
+  padding-top: calc(var(--nav-height) + 50px + var(--space-12));
+}
+.module-content { max-width: var(--content-width); margin: 0 auto; }
+.module-header { margin-bottom: var(--space-12); }
+.module-number {
+  font-family: var(--font-display); font-size: var(--text-6xl); font-weight: 800;
+  color: var(--color-accent); opacity: 0.15; line-height: 1; display: block;
+  margin-bottom: var(--space-2);
+}
+.module-title {
+  font-family: var(--font-display); font-size: var(--text-4xl); font-weight: 700;
+  line-height: var(--leading-tight); margin-bottom: var(--space-3);
+}
+.module-subtitle {
+  font-size: var(--text-lg); color: var(--color-text-secondary);
+  line-height: var(--leading-snug);
+}
+.screen { margin-bottom: var(--space-16); }
+.screen-heading {
+  font-family: var(--font-display); font-size: var(--text-2xl); font-weight: 600;
+  margin-bottom: var(--space-6); line-height: var(--leading-snug);
+}
+.screen p { margin-bottom: var(--space-4); max-width: 65ch; }
+
+/* ============================================================
+   ANIMATIONS
+   ============================================================ */
+.animate-in { opacity: 0; transform: translateY(20px); transition: opacity var(--duration-slow) var(--ease-out), transform var(--duration-slow) var(--ease-out); }
+.animate-in.visible { opacity: 1; transform: translateY(0); }
+.stagger-children > .animate-in { transition-delay: calc(var(--stagger-index, 0) * var(--stagger-delay)); }
+@keyframes fadeSlideUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes typingBounce { 0%, 60%, 100% { transform: translateY(0); } 30% { transform: translateY(-6px); } }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+@keyframes packetMove { 0% { left: var(--from-x); top: var(--from-y); opacity: 1; } 100% { left: var(--to-x); top: var(--to-y); opacity: 1; } }
+
+/* ============================================================
+   TRANSLATION BLOCKS
+   ============================================================ */
+.translation-block {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+  border-radius: var(--radius-md); overflow: hidden;
+  box-shadow: var(--shadow-md); margin: var(--space-8) 0;
+}
+.translation-code {
+  background: var(--color-bg-code); color: #CDD6F4;
+  padding: var(--space-6); font-family: var(--font-mono);
+  font-size: var(--text-sm); line-height: 1.7; position: relative;
+  overflow-x: hidden;
+}
+.translation-code pre, .translation-code code { white-space: pre-wrap; word-break: break-word; overflow-x: hidden; }
+.translation-english {
+  background: var(--color-surface-warm); padding: var(--space-6);
+  font-size: var(--text-sm); line-height: 1.7;
+  border-left: 3px solid var(--color-accent);
+}
+.translation-label {
+  position: absolute; top: var(--space-2); right: var(--space-3);
+  font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.1em; opacity: 0.5;
+}
+.translation-english .translation-label { color: var(--color-text-muted); position: relative; top: auto; right: auto; display: block; margin-bottom: var(--space-3); }
+.tl { margin-bottom: var(--space-3); padding-left: var(--space-3); border-left: 2px solid var(--color-border-light); }
+.code-keyword  { color: #CBA6F7; }
+.code-string   { color: #A6E3A1; }
+.code-function { color: #89B4FA; }
+.code-comment  { color: #6C7086; }
+.code-number   { color: #FAB387; }
+.code-property { color: #F9E2AF; }
+.code-operator { color: #94E2D5; }
+
+/* ============================================================
+   CALLOUT BOXES
+   ============================================================ */
+.callout {
+  display: flex; gap: var(--space-4); padding: var(--space-5) var(--space-6);
+  border-radius: var(--radius-md); margin: var(--space-8) 0;
+}
+.callout-accent { background: var(--color-accent-light); border-left: 4px solid var(--color-accent); }
+.callout-info { background: var(--color-info-light); border-left: 4px solid var(--color-info); }
+.callout-warning { background: var(--color-error-light); border-left: 4px solid var(--color-error); }
+.callout-icon { font-size: 1.5rem; flex-shrink: 0; }
+.callout-title { display: block; font-weight: 600; margin-bottom: var(--space-1); font-family: var(--font-display); }
+.callout-content p { margin-bottom: var(--space-2); font-size: var(--text-sm); }
+
+/* ============================================================
+   PATTERN CARDS
+   ============================================================ */
+.pattern-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--space-4); margin: var(--space-8) 0; }
+.pattern-card {
+  background: var(--color-surface); border-radius: var(--radius-md);
+  padding: var(--space-6); box-shadow: var(--shadow-sm);
+  transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal);
+}
+.pattern-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
+.pattern-icon { width: 40px; height: 40px; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: 1.25rem; margin-bottom: var(--space-3); color: white; }
+.pattern-title { font-family: var(--font-display); font-weight: 600; margin-bottom: var(--space-2); }
+.pattern-desc { font-size: var(--text-sm); color: var(--color-text-secondary); }
+
+/* ============================================================
+   ICON ROWS
+   ============================================================ */
+.icon-rows { display: flex; flex-direction: column; gap: var(--space-4); margin: var(--space-8) 0; }
+.icon-row {
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: var(--space-4); background: var(--color-surface);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-sm);
+}
+.icon-row p { margin: 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+.icon-circle {
+  width: 48px; height: 48px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1.25rem; flex-shrink: 0; color: white;
+}
+
+/* ============================================================
+   STEP CARDS
+   ============================================================ */
+.step-cards { display: flex; flex-direction: column; gap: var(--space-3); margin: var(--space-8) 0; }
+.step-card {
+  display: flex; align-items: flex-start; gap: var(--space-4);
+  padding: var(--space-4) var(--space-5); background: var(--color-surface);
+  border-radius: var(--radius-md); border-left: 3px solid var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+.step-num {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--color-accent); color: white; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); flex-shrink: 0;
+}
+.step-body p { margin: var(--space-1) 0 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+
+/* ============================================================
+   FILE TREE
+   ============================================================ */
+.file-tree { font-family: var(--font-mono); font-size: var(--text-sm); margin: var(--space-8) 0; background: var(--color-surface); padding: var(--space-6); border-radius: var(--radius-md); box-shadow: var(--shadow-sm); }
+.ft-folder, .ft-file { padding: var(--space-2) var(--space-3); border-left: 2px solid var(--color-border-light); margin-left: var(--space-4); }
+.ft-folder > .ft-name { color: var(--color-accent); font-weight: 600; }
+.ft-file > .ft-name { color: var(--color-text); }
+.ft-desc { color: var(--color-text-secondary); font-family: var(--font-body); margin-left: var(--space-2); font-size: var(--text-xs); }
+.ft-children { margin-left: var(--space-4); }
+
+/* ============================================================
+   CHAT ANIMATION
+   ============================================================ */
+.chat-window {
+  background: var(--color-surface); border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg); overflow: hidden; margin: var(--space-8) 0;
+  border: 1px solid var(--color-border-light);
+}
+.chat-header { background: var(--color-bg-code); color: #CDD6F4; padding: var(--space-3) var(--space-5); font-family: var(--font-mono); font-size: var(--text-sm); font-weight: 600; }
+.chat-messages { padding: var(--space-5); min-height: 200px; max-height: 450px; overflow-y: auto; display: flex; flex-direction: column; gap: var(--space-4); }
+.chat-message { display: flex; gap: var(--space-3); align-items: flex-start; }
+.chat-avatar { width: 36px; height: 36px; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: white; font-weight: 700; font-size: var(--text-sm); font-family: var(--font-mono); flex-shrink: 0; }
+.chat-bubble { background: var(--color-bg); padding: var(--space-3) var(--space-4); border-radius: var(--radius-md); max-width: 80%; }
+.chat-sender { font-weight: 600; font-size: var(--text-xs); display: block; margin-bottom: var(--space-1); text-transform: uppercase; letter-spacing: 0.05em; }
+.chat-bubble p { font-size: var(--text-sm); margin: 0; }
+.chat-typing { display: flex; gap: var(--space-3); align-items: center; padding: 0 var(--space-5) var(--space-3); }
+.chat-typing-dots { display: flex; gap: 4px; }
+.typing-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--color-text-muted); animation: typingBounce 1.4s infinite; }
+.typing-dot:nth-child(2) { animation-delay: 0.2s; }
+.typing-dot:nth-child(3) { animation-delay: 0.4s; }
+.chat-controls { display: flex; gap: var(--space-3); padding: var(--space-3) var(--space-5); border-top: 1px solid var(--color-border-light); align-items: center; flex-wrap: wrap; }
+.chat-controls button {
+  padding: var(--space-2) var(--space-4); border: 1px solid var(--color-border);
+  border-radius: var(--radius-full); background: var(--color-surface);
+  cursor: pointer; font-family: var(--font-body); font-size: var(--text-sm);
+  transition: all var(--duration-fast);
+}
+.chat-controls button:hover { border-color: var(--color-accent); color: var(--color-accent); }
+.chat-progress { font-size: var(--text-xs); color: var(--color-text-muted); margin-left: auto; }
+
+/* ============================================================
+   FLOW ANIMATION
+   ============================================================ */
+.flow-animation {
+  background: var(--color-surface); border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg); padding: var(--space-8); margin: var(--space-8) 0;
+  position: relative; overflow: hidden;
+}
+.flow-actors { display: flex; justify-content: space-around; gap: var(--space-4); flex-wrap: wrap; margin-bottom: var(--space-8); }
+.flow-actor { text-align: center; transition: all var(--duration-normal) var(--ease-out); padding: var(--space-3); border-radius: var(--radius-md); }
+.flow-actor-icon {
+  width: 56px; height: 56px; border-radius: 50%; display: flex; align-items: center; justify-content: center;
+  color: white; font-weight: 700; font-size: 1.25rem; margin: 0 auto var(--space-2);
+  font-family: var(--font-mono); transition: all var(--duration-normal);
+}
+.flow-actor span { font-size: var(--text-sm); font-weight: 500; }
+.flow-actor.active { background: var(--color-accent-light); }
+.flow-actor.active .flow-actor-icon { box-shadow: 0 0 0 3px var(--color-accent), 0 0 20px rgba(217,79,48,0.2); transform: scale(1.1); }
+.flow-step-label {
+  text-align: center; font-size: var(--text-lg); font-weight: 500;
+  min-height: 60px; display: flex; align-items: center; justify-content: center;
+  padding: var(--space-4); background: var(--color-bg); border-radius: var(--radius-md);
+  margin-bottom: var(--space-6); transition: all var(--duration-normal);
+}
+.flow-controls { display: flex; gap: var(--space-3); justify-content: center; align-items: center; flex-wrap: wrap; }
+.flow-controls button {
+  padding: var(--space-2) var(--space-5); border: 2px solid var(--color-accent);
+  border-radius: var(--radius-full); background: transparent; color: var(--color-accent);
+  cursor: pointer; font-family: var(--font-body); font-weight: 600; font-size: var(--text-sm);
+  transition: all var(--duration-fast);
+}
+.flow-controls button:hover { background: var(--color-accent); color: white; }
+.flow-progress { font-size: var(--text-xs); color: var(--color-text-muted); }
+
+/* ============================================================
+   QUIZ
+   ============================================================ */
+.quiz-container { margin: var(--space-8) 0; }
+.quiz-question-block { margin-bottom: var(--space-8); }
+.quiz-question { font-family: var(--font-display); font-weight: 600; margin-bottom: var(--space-4); font-size: var(--text-lg); }
+.quiz-options { display: flex; flex-direction: column; gap: var(--space-2); }
+.quiz-option {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-4); border: 2px solid var(--color-border);
+  border-radius: var(--radius-sm); background: var(--color-surface);
+  cursor: pointer; width: 100%; transition: border-color var(--duration-fast), background var(--duration-fast);
+  font-family: var(--font-body); font-size: var(--text-sm); text-align: left;
+}
+.quiz-option:hover { border-color: var(--color-accent-muted); }
+.quiz-option.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
+.quiz-option.correct { border-color: var(--color-success); background: var(--color-success-light); }
+.quiz-option.incorrect { border-color: var(--color-error); background: var(--color-error-light); }
+.quiz-option-radio {
+  width: 18px; height: 18px; border-radius: 50%; border: 2px solid var(--color-border);
+  transition: all var(--duration-fast); flex-shrink: 0;
+}
+.quiz-option.selected .quiz-option-radio { border-color: var(--color-accent); background: var(--color-accent); box-shadow: inset 0 0 0 3px white; }
+.quiz-option.correct .quiz-option-radio { border-color: var(--color-success); background: var(--color-success); box-shadow: inset 0 0 0 3px white; }
+.quiz-option.incorrect .quiz-option-radio { border-color: var(--color-error); background: var(--color-error); box-shadow: inset 0 0 0 3px white; }
+.quiz-feedback { max-height: 0; overflow: hidden; opacity: 0; transition: max-height var(--duration-normal), opacity var(--duration-normal), padding var(--duration-normal); border-radius: var(--radius-sm); font-size: var(--text-sm); }
+.quiz-feedback.show { max-height: 200px; opacity: 1; padding: var(--space-3) var(--space-4); margin-top: var(--space-2); }
+.quiz-feedback.success { background: var(--color-success-light); color: var(--color-success); }
+.quiz-feedback.error { background: var(--color-error-light); color: var(--color-error); }
+.quiz-check-btn {
+  margin-top: var(--space-4); padding: var(--space-3) var(--space-8);
+  background: var(--color-accent); color: white; border: none; border-radius: var(--radius-full);
+  font-family: var(--font-display); font-weight: 600; font-size: var(--text-base);
+  cursor: pointer; transition: background var(--duration-fast);
+}
+.quiz-check-btn:hover { background: var(--color-accent-hover); }
+
+/* ============================================================
+   GLOSSARY TOOLTIPS
+   ============================================================ */
+.term { border-bottom: 1.5px dashed var(--color-accent-muted); cursor: pointer; position: relative; }
+.term:hover, .term.active { border-bottom-color: var(--color-accent); color: var(--color-accent); }
+.term-tooltip {
+  position: fixed; background: var(--color-bg-code); color: #CDD6F4;
+  padding: var(--space-3) var(--space-4); border-radius: var(--radius-sm);
+  font-size: var(--text-sm); font-family: var(--font-body); line-height: var(--leading-normal);
+  width: max(200px, min(320px, 80vw)); box-shadow: var(--shadow-lg);
+  pointer-events: none; opacity: 0; transition: opacity var(--duration-fast); z-index: 10000;
+}
+.term-tooltip::after {
+  content: ''; position: absolute; top: 100%; left: 50%; transform: translateX(-50%);
+  border: 6px solid transparent; border-top-color: var(--color-bg-code);
+}
+.term-tooltip.visible { opacity: 1; }
+.term-tooltip.flip::after { top: auto; bottom: 100%; border-top-color: transparent; border-bottom-color: var(--color-bg-code); }
+
+/* ============================================================
+   BADGE LIST
+   ============================================================ */
+.badge-list { display: flex; flex-direction: column; gap: var(--space-2); margin: var(--space-6) 0; }
+.badge-item {
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: var(--space-3) var(--space-4); border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm); transition: border-color var(--duration-fast);
+}
+.badge-item:hover { border-color: var(--color-accent-muted); }
+.badge-code {
+  font-family: var(--font-mono); font-size: var(--text-sm);
+  background: var(--color-bg-code); color: #CBA6F7;
+  padding: var(--space-1) var(--space-3); border-radius: var(--radius-sm); white-space: nowrap;
+}
+
+/* ============================================================
+   SCENARIO BLOCK
+   ============================================================ */
+.scenario-block { background: var(--color-surface-warm); border-radius: var(--radius-md); padding: var(--space-5) var(--space-6); margin: var(--space-6) 0; border: 1px solid var(--color-border-light); }
+.scenario-label { font-size: var(--text-xs); font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-accent); font-weight: 600; display: block; margin-bottom: var(--space-2); }
+.scenario-block > p { font-size: var(--text-sm); color: var(--color-text-secondary); margin-bottom: var(--space-4); }
+
+/* ============================================================
+   ARCH DIAGRAM
+   ============================================================ */
+.arch-diagram { background: var(--color-surface); border-radius: var(--radius-lg); box-shadow: var(--shadow-md); padding: var(--space-6); margin: var(--space-8) 0; }
+.arch-zones { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); margin-bottom: var(--space-6); }
+.arch-zone { padding: var(--space-4); border-radius: var(--radius-md); border: 2px dashed var(--color-border); }
+.arch-zone-label { font-family: var(--font-mono); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-text-muted); margin-bottom: var(--space-3); }
+.arch-component {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3); border-radius: var(--radius-sm);
+  cursor: pointer; transition: all var(--duration-fast);
+  border: 1px solid transparent;
+}
+.arch-component:hover { border-color: var(--color-accent); background: var(--color-accent-light); }
+.arch-component.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
+.arch-icon { font-size: 1.25rem; }
+.arch-component span { font-size: var(--text-sm); font-weight: 500; }
+.arch-description { padding: var(--space-4); background: var(--color-bg); border-radius: var(--radius-sm); font-size: var(--text-sm); color: var(--color-text-secondary); min-height: 50px; text-align: center; }
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width: 768px) {
+  :root { --text-4xl: 1.875rem; --text-5xl: 2.25rem; --text-6xl: 3rem; }
+  .translation-block { grid-template-columns: 1fr; }
+  .translation-english { border-left: none; border-top: 3px solid var(--color-accent); }
+  .pattern-cards { grid-template-columns: 1fr 1fr; }
+  .arch-zones { grid-template-columns: 1fr; }
+  .flow-actors { gap: var(--space-2); }
+}
+@media (max-width: 480px) {
+  :root { --text-4xl: 1.5rem; --text-5xl: 1.875rem; --text-6xl: 2.25rem; }
+  .module { padding: var(--space-8) var(--space-4); }
+  .pattern-cards { grid-template-columns: 1fr; }
+}
+
+/* ============================================================
+   HERO
+   ============================================================ */
+.hero-module { display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
+.hero-module .module-header { text-align: center; }
+.hero-badge { display: inline-block; padding: var(--space-1) var(--space-4); background: var(--color-accent-light); color: var(--color-accent); border-radius: var(--radius-full); font-size: var(--text-sm); font-weight: 600; margin-bottom: var(--space-6); font-family: var(--font-mono); }
+.hero-title { font-family: var(--font-display); font-size: var(--text-5xl); font-weight: 800; line-height: var(--leading-tight); margin-bottom: var(--space-6); }
+.hero-subtitle { font-size: var(--text-xl); color: var(--color-text-secondary); max-width: 600px; margin: 0 auto var(--space-8); }
+.hero-stats { display: flex; gap: var(--space-8); justify-content: center; flex-wrap: wrap; margin-top: var(--space-8); }
+.hero-stat { text-align: center; }
+.hero-stat-num { font-family: var(--font-display); font-size: var(--text-3xl); font-weight: 800; color: var(--color-accent); display: block; }
+.hero-stat-label { font-size: var(--text-sm); color: var(--color-text-muted); }
+.hero-scroll-hint { margin-top: var(--space-12); font-size: var(--text-sm); color: var(--color-text-muted); animation: pulse 2s infinite; }
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     SITE NAV
+     ============================================================ -->
+<nav class="site-nav" role="navigation" aria-label="Site navigation">
+  <a href="../" class="site-nav-brand">autoresearch</a>
+  <ul class="site-nav-links">
+    <li><a href="../benchmark/">Benchmark</a></li>
+    <li><a href="./" class="active">Course</a></li>
+    <li><a href="https://github.com/elementalcollision/autoresearch-unified" target="_blank">GitHub</a></li>
+  </ul>
+</nav>
+
+<!-- ============================================================
+     NAV
+     ============================================================ -->
+<nav class="nav" role="navigation" aria-label="Course navigation">
+  <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuenow="0"></div>
+  <div class="nav-inner">
+    <span class="nav-title">How Autoresearch Works</span>
+    <div class="nav-dots" role="tablist">
+      <button class="nav-dot" data-target="module-0" data-tooltip="Intro" role="tab" aria-label="Introduction"></button>
+      <button class="nav-dot" data-target="module-1" data-tooltip="First Run" role="tab" aria-label="Module 1"></button>
+      <button class="nav-dot" data-target="module-2" data-tooltip="Cast" role="tab" aria-label="Module 2"></button>
+      <button class="nav-dot" data-target="module-3" data-tooltip="Loop" role="tab" aria-label="Module 3"></button>
+      <button class="nav-dot" data-target="module-4" data-tooltip="Brain" role="tab" aria-label="Module 4"></button>
+      <button class="nav-dot" data-target="module-5" data-tooltip="Tricks" role="tab" aria-label="Module 5"></button>
+      <button class="nav-dot" data-target="module-6" data-tooltip="Resilience" role="tab" aria-label="Module 6"></button>
+      <button class="nav-dot" data-target="module-7" data-tooltip="Big Picture" role="tab" aria-label="Module 7"></button>
+    </div>
+  </div>
+</nav>
+
+<!-- ============================================================
+     MODULE 0: HERO
+     ============================================================ -->
+<section class="module hero-module" id="module-0" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="hero-badge">Interactive Course</span>
+      <h1 class="hero-title">How Autoresearch Works</h1>
+      <p class="hero-subtitle">An AI scientist that runs thousands of GPU experiments autonomously &mdash; and the code that makes it tick. No CS degree required.</p>
+    </header>
+    <div class="hero-stats animate-in stagger-children">
+      <div class="hero-stat" style="--stagger-index:0"><span class="hero-stat-num">2,637+</span><span class="hero-stat-label">Experiments run</span></div>
+      <div class="hero-stat" style="--stagger-index:1"><span class="hero-stat-num">4</span><span class="hero-stat-label">GPU platforms</span></div>
+      <div class="hero-stat" style="--stagger-index:2"><span class="hero-stat-num">5 min</span><span class="hero-stat-label">Per experiment</span></div>
+      <div class="hero-stat" style="--stagger-index:3"><span class="hero-stat-num">1</span><span class="hero-stat-label">AI scientist (Claude)</span></div>
+    </div>
+    <p class="hero-scroll-hint animate-in">Scroll down to begin &darr;</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     MODULE 1: WHAT HAPPENS WHEN YOU HIT "RUN"
+     ============================================================ -->
+<section class="module" id="module-1" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">01</span>
+      <h1 class="module-title">What Happens When You Hit "Run"</h1>
+      <p class="module-subtitle">Trace the journey from a single command to a trained neural network</p>
+    </header>
+
+    <div class="module-body">
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The One-Line Magic Trick</h2>
+        <p>Imagine you&rsquo;re a researcher. You sit down at a computer connected to a powerful <span class="term" data-definition="A GPU (Graphics Processing Unit) is a specialized chip originally built for rendering video game graphics, but it turns out to be incredible at the math needed for AI training. Think of it as a factory with thousands of tiny workers that can all do simple math at the same time.">GPU</span>, type <code>python train.py</code>, and walk away. Five minutes later, you have a trained language model and a score that tells you how good it is.</p>
+        <p>But what actually happened in those five minutes? Let's trace every step.</p>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Step 1: The Dispatcher</h2>
+        <p>The very first thing that runs is <code>train.py</code> &mdash; a tiny 40-line file whose only job is to figure out <em>what kind of GPU you have</em> and hand off to the right specialist.</p>
+        <p>Think of it like a hospital receptionist. You walk in and say "I need help." The receptionist doesn't treat you &mdash; they figure out which department to send you to.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-keyword">from</span> backends <span class="code-keyword">import</span> <span class="code-function">detect_backend</span>
+<span class="code-keyword">from</span> backends.registry <span class="code-keyword">import</span> <span class="code-function">get_training_script</span>
+
+backend = <span class="code-function">detect_backend</span>()
+script_path = <span class="code-function">get_training_script</span>(backend)
+
+os.<span class="code-function">execv</span>(sys.executable, [sys.executable, script_path])</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Bring in the "detective" tools that can identify GPU hardware</p>
+              <p class="tl">&nbsp;</p>
+              <p class="tl">Ask: "What GPU is installed on this machine?"</p>
+              <p class="tl">Look up: "For that GPU type, which training script should I run?"</p>
+              <p class="tl">&nbsp;</p>
+              <p class="tl">Replace myself entirely with the specialist script &mdash; I'm done, the specialist takes over from here</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent animate-in">
+          <div class="callout-icon">&#x1f4a1;</div>
+          <div class="callout-content">
+            <strong class="callout-title">Key Insight: The Dispatcher Pattern</strong>
+            <p>This "detect and hand off" pattern is everywhere in software. Your phone does it when you tap a link &mdash; it figures out which app should open it (Safari? Chrome? YouTube?) and hands it off. When you tell an AI agent "build me a website," this pattern is how it figures out which tool to use for each step.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Step 2: Detection Priority</h2>
+        <p>The detective checks hardware in a specific order, from most powerful to most common:</p>
+
+        <div class="step-cards stagger-children">
+          <div class="step-card animate-in" style="--stagger-index:0"><div class="step-num">1</div><div class="step-body"><strong>Intel Gaudi HPU</strong><p>Specialized AI chips &mdash; rarest, but purpose-built for training</p></div></div>
+          <div class="step-card animate-in" style="--stagger-index:1"><div class="step-num">2</div><div class="step-body"><strong>AMD ROCm (MI300X)</strong><p>AMD's datacenter GPUs &mdash; 192 GB of memory, massive compute</p></div></div>
+          <div class="step-card animate-in" style="--stagger-index:2"><div class="step-num">3</div><div class="step-body"><strong>NVIDIA CUDA</strong><p>The industry standard &mdash; from RTX 4090 to H100</p></div></div>
+          <div class="step-card animate-in" style="--stagger-index:3"><div class="step-num">4</div><div class="step-body"><strong>Apple MLX / MPS</strong><p>Your MacBook's built-in GPU &mdash; surprisingly capable</p></div></div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Step 3: Five Minutes of Training</h2>
+        <p>Once the specialist script takes over, the same thing happens on every platform: build a small <span class="term" data-definition="A neural network is a program loosely inspired by the brain. It's made of layers of simple math operations that, when stacked together, can learn to predict text, recognize images, or generate code. Think of it as a very sophisticated pattern-matching machine.">neural network</span>, feed it text data for exactly 5 minutes, then measure how well it learned.</p>
+
+        <div class="flow-animation animate-in" id="flow-training">
+          <div class="flow-actors">
+            <div class="flow-actor" id="ft-data"><div class="flow-actor-icon" style="background: var(--color-actor-2)">D</div><span>Data Loader</span></div>
+            <div class="flow-actor" id="ft-model"><div class="flow-actor-icon" style="background: var(--color-actor-3)">M</div><span>Neural Network</span></div>
+            <div class="flow-actor" id="ft-optim"><div class="flow-actor-icon" style="background: var(--color-actor-4)">O</div><span>Optimizer</span></div>
+            <div class="flow-actor" id="ft-eval"><div class="flow-actor-icon" style="background: var(--color-actor-5)">E</div><span>Evaluator</span></div>
+          </div>
+          <div class="flow-step-label" id="ft-label">Click "Next Step" to see the training loop</div>
+          <div class="flow-controls">
+            <button onclick="ftNext()">Next Step</button>
+            <button onclick="ftReset()">Restart</button>
+            <span class="flow-progress" id="ft-progress">Step 0 / 6</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Quiz -->
+      <section class="screen animate-in" id="quiz-m1">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <div class="quiz-container">
+          <div class="quiz-question-block" data-question="m1q1" data-correct="b">
+            <h3 class="quiz-question">You want to add support for a brand-new GPU from a startup called "NovAI." Where would you start?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Rewrite train.py to include NovAI-specific code</span></button>
+              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Add a new entry to the backends registry and create a new platform training script</span></button>
+              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Modify every existing training script to also check for NovAI hardware</span></button>
+            </div>
+            <div class="quiz-feedback" data-correct-text="The dispatcher pattern means train.py never needs to change. You'd add 'novai' to the registry, create platforms/novai/train_novai.py, and update detect_backend() &mdash; the rest of the system works automatically." data-incorrect-text="The whole point of the dispatcher is that train.py stays unchanged. You'd add the new backend to the registry and create a dedicated training script &mdash; no need to touch existing code."></div>
+          </div>
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m1')">Check Answer</button>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     MODULE 2: MEET THE CAST
+     ============================================================ -->
+<section class="module" id="module-2" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">02</span>
+      <h1 class="module-title">Meet the Cast</h1>
+      <p class="module-subtitle">Every software project has characters. Here are the actors in this one.</p>
+    </header>
+
+    <div class="module-body">
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Six Main Characters</h2>
+        <p>Think of this codebase like a film production. Each character has a specific role, and the movie falls apart if any one of them goes missing.</p>
+
+        <div class="icon-rows stagger-children">
+          <div class="icon-row animate-in" style="--stagger-index:0">
+            <div class="icon-circle" style="background: var(--color-actor-1)">O</div>
+            <div><strong>The Orchestrator</strong> <code>tui/orchestrator.py</code><p>The director. Runs the experiment loop, tells everyone what to do, keeps track of results.</p></div>
+          </div>
+          <div class="icon-row animate-in" style="--stagger-index:1">
+            <div class="icon-circle" style="background: var(--color-actor-2)">C</div>
+            <div><strong>Claude (LLM Backend)</strong> <code>tui/llm_backend.py</code><p>The scientist. Analyzes past experiments and proposes what to try next.</p></div>
+          </div>
+          <div class="icon-row animate-in" style="--stagger-index:2">
+            <div class="icon-circle" style="background: var(--color-actor-3)">T</div>
+            <div><strong>The Trainer</strong> <code>platforms/*/train_*.py</code><p>The lab technician. Actually runs the GPU and trains the neural network.</p></div>
+          </div>
+          <div class="icon-row animate-in" style="--stagger-index:3">
+            <div class="icon-circle" style="background: var(--color-actor-4)">G</div>
+            <div><strong>Git Manager</strong> <code>tui/git_manager.py</code><p>The librarian. Saves every experiment as a permanent record you can revisit.</p></div>
+          </div>
+          <div class="icon-row animate-in" style="--stagger-index:4">
+            <div class="icon-circle" style="background: var(--color-actor-5)">R</div>
+            <div><strong>Results Logger</strong> <code>tui/results.py</code><p>The scorekeeper. Writes results to a spreadsheet that never loses data, even if the power goes out.</p></div>
+          </div>
+          <div class="icon-row animate-in" style="--stagger-index:5">
+            <div class="icon-circle" style="background: #888">P</div>
+            <div><strong>Data Preparer</strong> <code>prepare.py</code><p>The prep cook. Downloads training data and builds the vocabulary before anyone else starts working.</p></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Project Layout</h2>
+        <p>Here's how these characters are organized in the actual code:</p>
+
+        <div class="file-tree animate-in">
+          <div class="ft-folder open">
+            <span class="ft-name">autoresearch-unified/</span>
+            <div class="ft-children">
+              <div class="ft-file"><span class="ft-name">train.py</span> <span class="ft-desc">The receptionist (40 lines)</span></div>
+              <div class="ft-file"><span class="ft-name">prepare.py</span> <span class="ft-desc">Downloads data + trains tokenizer</span></div>
+              <div class="ft-file"><span class="ft-name">run_suite.py</span> <span class="ft-desc">Runs experiments across many datasets overnight</span></div>
+              <div class="ft-folder open">
+                <span class="ft-name">tui/</span> <span class="ft-desc">The brain &mdash; orchestration, UI, Claude API</span>
+                <div class="ft-children">
+                  <div class="ft-file"><span class="ft-name">orchestrator.py</span> <span class="ft-desc">The director (880 lines)</span></div>
+                  <div class="ft-file"><span class="ft-name">llm_backend.py</span> <span class="ft-desc">Talks to Claude</span></div>
+                  <div class="ft-file"><span class="ft-name">results.py</span> <span class="ft-desc">Crash-safe scorekeeper</span></div>
+                  <div class="ft-file"><span class="ft-name">resilience.py</span> <span class="ft-desc">Crash protection</span></div>
+                </div>
+              </div>
+              <div class="ft-folder open">
+                <span class="ft-name">backends/</span> <span class="ft-desc">GPU detection + optimizers</span>
+                <div class="ft-children">
+                  <div class="ft-file"><span class="ft-name">__init__.py</span> <span class="ft-desc">Hardware detective</span></div>
+                  <div class="ft-file"><span class="ft-name">muon_cuda.py</span> <span class="ft-desc">NVIDIA optimizer</span></div>
+                  <div class="ft-file"><span class="ft-name">muon_rocm.py</span> <span class="ft-desc">AMD optimizer</span></div>
+                  <div class="ft-file"><span class="ft-name">muon_mlx.py</span> <span class="ft-desc">Apple optimizer</span></div>
+                </div>
+              </div>
+              <div class="ft-folder open">
+                <span class="ft-name">platforms/</span> <span class="ft-desc">One training script per GPU type</span>
+                <div class="ft-children">
+                  <div class="ft-folder"><span class="ft-name">cuda/</span> <span class="ft-desc">NVIDIA GPUs</span></div>
+                  <div class="ft-folder"><span class="ft-name">rocm/</span> <span class="ft-desc">AMD GPUs</span></div>
+                  <div class="ft-folder"><span class="ft-name">metal/</span> <span class="ft-desc">Apple Silicon</span></div>
+                  <div class="ft-folder"><span class="ft-name">gaudi/</span> <span class="ft-desc">Intel Gaudi</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">How They Talk to Each Other</h2>
+        <p>Watch how the Orchestrator coordinates a single experiment:</p>
+
+        <div class="chat-window" id="chat-cast">
+          <div class="chat-header">Experiment #42 &mdash; Component Chat</div>
+          <div class="chat-messages" id="chat-cast-msgs">
+            <div class="chat-message" data-sender="orch" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-1)">O</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">Orchestrator</span><p>Hey Claude, here are the results from our last 41 experiments. What should we try next?</p></div></div>
+            <div class="chat-message" data-sender="claude" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-2)">C</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-2)">Claude</span><p>Looking at the trend... the learning rate sweet spot seems to be around 0.003. Let's try increasing the model depth from 8 to 10 layers.</p></div></div>
+            <div class="chat-message" data-sender="orch" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-1)">O</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">Orchestrator</span><p>Got it. Git Manager, save the current code and commit this change.</p></div></div>
+            <div class="chat-message" data-sender="git" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-4)">G</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-4)">Git Manager</span><p>Done! Committed as "exp42: increase depth from 8 to 10 layers" &mdash; SHA: a1b2c3d</p></div></div>
+            <div class="chat-message" data-sender="orch" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-1)">O</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">Orchestrator</span><p>Trainer, run this for 5 minutes on the GPU.</p></div></div>
+            <div class="chat-message" data-sender="trainer" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-3)">T</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-3)">Trainer</span><p>Training complete! val_bpb: 1.234, that's better than our previous best of 1.289!</p></div></div>
+            <div class="chat-message" data-sender="orch" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-1)">O</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">Orchestrator</span><p>New record! Results Logger, mark this as KEEP.</p></div></div>
+            <div class="chat-message" data-sender="results" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-5)">R</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-5)">Results Logger</span><p>Saved to results.tsv with atomic write. Even if the power dies right now, this result is safe.</p></div></div>
+          </div>
+          <div class="chat-typing" id="chat-cast-typing" style="display:none">
+            <div class="chat-avatar" id="cast-typing-avatar" style="background: var(--color-text-muted)">?</div>
+            <div class="chat-typing-dots"><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div>
+          </div>
+          <div class="chat-controls">
+            <button onclick="playChatNext('cast')">Next Message</button>
+            <button onclick="playChatAll('cast')">Play All</button>
+            <button onclick="resetChat('cast')">Replay</button>
+            <span class="chat-progress" id="chat-cast-progress">0 / 8 messages</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Quiz -->
+      <section class="screen animate-in" id="quiz-m2">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <div class="quiz-container">
+          <div class="quiz-question-block" data-question="m2q1" data-correct="b">
+            <h3 class="quiz-question">The training just finished, but the results show a worse score than before. Which component decides whether to keep or discard the experiment?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Claude (the LLM Backend)</span></button>
+              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The Orchestrator</span></button>
+              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The Trainer</span></button>
+            </div>
+            <div class="quiz-feedback" data-correct-text="The Orchestrator compares the new val_bpb against the best so far and decides keep/discard. Claude proposes experiments but doesn't judge results &mdash; the Orchestrator is the decision-maker." data-incorrect-text="Claude proposes experiments and the Trainer runs them, but the Orchestrator is the one who compares scores and marks experiments as 'keep' or 'discard.'"></div>
+          </div>
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m2')">Check Answer</button>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     MODULE 3: THE EXPERIMENT LOOP
+     ============================================================ -->
+<section class="module" id="module-3" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">03</span>
+      <h1 class="module-title">The Experiment Loop</h1>
+      <p class="module-subtitle">The engine that runs thousands of experiments while you sleep</p>
+    </header>
+
+    <div class="module-body">
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Scientific Method, Automated</h2>
+        <p>Traditional research: a human reads papers, forms a hypothesis, runs an experiment, analyzes results, and repeats. This system does the same thing, but the "human" is <span class="term" data-definition="Claude is an AI assistant made by Anthropic. In this system, it acts as the 'scientist' &mdash; reading past experimental results and proposing what to try next, like a researcher who never sleeps and has perfect memory of every past experiment.">Claude</span>, and it never needs sleep.</p>
+        <p>Each cycle takes about 6 minutes: 1 minute for Claude to think + 5 minutes of training. That means roughly 80 experiments per 8-hour overnight run.</p>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What Claude Actually Sees</h2>
+        <p>Before each experiment, the Orchestrator sends Claude a carefully crafted message containing the experiment history and the editable code. Claude's job: change ONE thing in the <span class="term" data-definition="Hyperparameters are the 'knobs and dials' of a neural network &mdash; settings like learning rate, model size, and batch size that you choose before training. They're 'hyper' because they control the regular parameters that the model learns on its own.">hyperparameter</span> block.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">WHAT CLAUDE SEES</span>
+            <pre><code><span class="code-comment"># Hyperparameters</span>
+DEPTH = <span class="code-number">8</span>
+DEVICE_BATCH_SIZE = <span class="code-number">64</span>
+TOTAL_BATCH_SIZE = <span class="code-number">2</span> ** <span class="code-number">17</span>
+LEARNING_RATE = <span class="code-number">0.003</span>
+WEIGHT_DECAY = <span class="code-number">0.05</span>
+WARMUP_ITERS = <span class="code-number">0</span>
+COOLDOWN_FRAC = <span class="code-number">0.4</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">These are the settings Claude can adjust:</p>
+              <p class="tl"><strong>DEPTH = 8</strong> &mdash; How many layers deep the brain is (more = smarter, but slower)</p>
+              <p class="tl"><strong>DEVICE_BATCH_SIZE = 64</strong> &mdash; How many text samples to process at once</p>
+              <p class="tl"><strong>TOTAL_BATCH_SIZE</strong> &mdash; Total samples before updating the brain</p>
+              <p class="tl"><strong>LEARNING_RATE</strong> &mdash; How aggressively to learn (too high = unstable, too low = slow)</p>
+              <p class="tl"><strong>WEIGHT_DECAY</strong> &mdash; Slight "forgetfulness" that prevents over-memorizing</p>
+              <p class="tl"><strong>WARMUP_ITERS</strong> &mdash; Steps of gentle start before full speed</p>
+              <p class="tl"><strong>COOLDOWN_FRAC</strong> &mdash; Portion of time spent gradually slowing down</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Results Spreadsheet</h2>
+        <p>Every experiment produces one row in a <span class="term" data-definition="TSV stands for Tab-Separated Values &mdash; a simple spreadsheet format where each column is separated by a tab character. Think of it as a super-simple Excel file that any program can read.">TSV</span> file. This is the project's source of truth &mdash; the complete history of every experiment ever run.</p>
+
+        <div class="badge-list animate-in">
+          <div class="badge-item"><code class="badge-code">exp</code><span>Experiment number (exp0, exp1, exp2...)</span></div>
+          <div class="badge-item"><code class="badge-code">description</code><span>What Claude changed ("increase depth to 10")</span></div>
+          <div class="badge-item"><code class="badge-code">val_bpb</code><span>The score &mdash; lower is better (bits per byte)</span></div>
+          <div class="badge-item"><code class="badge-code">mfu</code><span>How efficiently the GPU was used (%)</span></div>
+          <div class="badge-item"><code class="badge-code">status</code><span>keep, discard, baseline, or crash</span></div>
+          <div class="badge-item"><code class="badge-code">baseline_sha</code><span>Git fingerprint linking to exact code version</span></div>
+        </div>
+
+        <div class="callout callout-info animate-in">
+          <div class="callout-icon">&#x1f50d;</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why "Bits Per Byte"?</strong>
+            <p>Different <span class="term" data-definition="A tokenizer breaks text into chunks called tokens. 'Hello world' might become ['Hello', ' world'] &mdash; two tokens. Different tokenizers break text differently, like how different languages carve up words differently.">tokenizers</span> split text into different-sized pieces, making raw loss numbers incomparable. Bits-per-byte converts to a universal scale: "how many bits of information do you need to predict each byte of text?" Lower means the model learned better patterns.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Quiz -->
+      <section class="screen animate-in" id="quiz-m3">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <div class="quiz-container">
+          <div class="quiz-question-block" data-question="m3q1" data-correct="c">
+            <h3 class="quiz-question">Claude proposes changing BOTH the learning rate and the model depth at the same time. Why would the system's rules prevent this?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Changing two things uses too much GPU memory</span></button>
+              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The code can only handle one change per commit</span></button>
+              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>If the result improves, you won't know which change caused it</span></button>
+            </div>
+            <div class="quiz-feedback" data-correct-text="Exactly! This is the scientific principle of 'controlled experiments' &mdash; change one variable at a time so you can attribute cause and effect. If you change two things and the score improves, you learn nothing about which one helped." data-incorrect-text="The real reason is scientific rigor: if you change two things and the result improves, you can't tell which change helped. The system enforces ONE change per experiment so every result is interpretable."></div>
+          </div>
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m3')">Check Answer</button>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     MODULE 4: INSIDE THE NEURAL NETWORK
+     ============================================================ -->
+<section class="module" id="module-4" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">04</span>
+      <h1 class="module-title">Inside the Neural Network</h1>
+      <p class="module-subtitle">What's actually inside the brain this system trains?</p>
+    </header>
+
+    <div class="module-body">
+      <section class="screen animate-in">
+        <h2 class="screen-heading">A Transformer, in Plain English</h2>
+        <p>The model is a <span class="term" data-definition="A Transformer is the architecture behind GPT, Claude, and most modern AI. It's called a 'transformer' because it transforms input text into output predictions using a mechanism called 'attention' that lets it focus on relevant words, regardless of how far apart they are.">Transformer</span> &mdash; the same family as GPT and Claude, but miniature. Where GPT-4 has hundreds of billions of <span class="term" data-definition="Parameters are the numbers the model learns during training. They're like the knobs on a mixing board &mdash; millions of tiny adjustments that together determine how the model responds to any input. More parameters generally means a more capable model.">parameters</span>, this one has 1&ndash;10 million. It's small enough to train in 5 minutes, but big enough to actually learn language patterns.</p>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Building Blocks</h2>
+        <p>Every Transformer is built from the same LEGO bricks, stacked on top of each other. Imagine a conveyor belt in a factory: raw text goes in one end, predictions come out the other, passing through specialized stations.</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2); --stagger-index:0">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">Aa</div>
+            <h4 class="pattern-title">Embedding</h4>
+            <p class="pattern-desc">Converts each word-piece into a list of numbers (a "vector") that the math can work with. Like translating English into the language of mathematics.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-3); --stagger-index:1">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">&#x1f441;</div>
+            <h4 class="pattern-title">Attention</h4>
+            <p class="pattern-desc">Each word "looks at" every other word to understand context. "Bank" means something different near "river" vs. "money." This layer figures that out.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4); --stagger-index:2">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">&#x26a1;</div>
+            <h4 class="pattern-title">MLP (ReLU²)</h4>
+            <p class="pattern-desc">A "thinking" layer that processes what attention found. It expands the information, applies a non-linear filter, then compresses it back down.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5); --stagger-index:3">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">&#x1f3af;</div>
+            <h4 class="pattern-title">Output Head</h4>
+            <p class="pattern-desc">Converts the final numbers back into a probability for every possible next word. The highest probability wins.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Clever Tricks</h2>
+        <p>This isn't a textbook Transformer. It uses several cutting-edge techniques that improve performance on small models:</p>
+
+        <div class="step-cards stagger-children">
+          <div class="step-card animate-in" style="--stagger-index:0; border-left-color: var(--color-actor-3)"><div class="step-num" style="background: var(--color-actor-3)">1</div><div class="step-body"><strong>Sliding Window Attention</strong><p>Not every layer needs to look at the full text. Alternate layers use a "short window" &mdash; like reading with a magnifying glass vs. scanning the whole page. Saves compute, barely hurts quality.</p></div></div>
+          <div class="step-card animate-in" style="--stagger-index:1; border-left-color: var(--color-actor-4)"><div class="step-num" style="background: var(--color-actor-4)">2</div><div class="step-body"><strong>Value Residual (ResFormer)</strong><p>Some layers get an extra "cheat sheet" that feeds raw vocabulary information directly into the attention. Like an open-book exam instead of pure memory.</p></div></div>
+          <div class="step-card animate-in" style="--stagger-index:2; border-left-color: var(--color-actor-5)"><div class="step-num" style="background: var(--color-actor-5)">3</div><div class="step-body"><strong>Learnable Residual Scaling</strong><p>Each layer gets its own volume dial. The model learns how much to "listen" to each layer's contribution vs. the original signal.</p></div></div>
+          <div class="step-card animate-in" style="--stagger-index:3; border-left-color: var(--color-actor-1)"><div class="step-num" style="background: var(--color-actor-1)">4</div><div class="step-body"><strong>Logit Softcap</strong><p>Prevents the model from becoming "too confident." A mathematical ceiling that squashes extreme predictions, keeping the model honest.</p></div></div>
+        </div>
+      </section>
+
+      <!-- Quiz -->
+      <section class="screen animate-in" id="quiz-m4">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <div class="quiz-container">
+          <div class="quiz-question-block" data-question="m4q1" data-correct="a">
+            <h3 class="quiz-question">You're building a chatbot and the AI keeps giving wildly overconfident answers. Which technique from this module could help?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Logit softcap &mdash; it squashes extreme predictions</span></button>
+              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Sliding window attention &mdash; it limits context</span></button>
+              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Value residual &mdash; it adds raw vocabulary information</span></button>
+            </div>
+            <div class="quiz-feedback" data-correct-text="Logit softcap applies tanh(logits / cap) * cap, mathematically preventing any prediction from becoming unreasonably extreme. It's like a speed limiter on confidence." data-incorrect-text="The logit softcap is specifically designed for this &mdash; it applies a mathematical ceiling that prevents any single prediction from becoming too extreme. Sliding window is about memory efficiency, and value residual adds information rather than limiting it."></div>
+          </div>
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m4')">Check Answer</button>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     MODULE 5: THE OPTIMIZER (SECRET SAUCE)
+     ============================================================ -->
+<section class="module" id="module-5" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">05</span>
+      <h1 class="module-title">The Secret Sauce: MuonAdamW</h1>
+      <p class="module-subtitle">The custom optimizer that's half math genius, half Swiss Army knife</p>
+    </header>
+
+    <div class="module-body">
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What Is an Optimizer?</h2>
+        <p>Training a neural network is like navigating a mountainous landscape blindfolded. You can feel the slope under your feet (the <span class="term" data-definition="A gradient tells you which direction is 'downhill' for each parameter. If you're training a model, gradients are the compass &mdash; they point toward settings that would reduce errors. The optimizer uses gradients to decide which direction to adjust the model's millions of parameters.">gradient</span>), but you need a strategy for which direction to step and how far. That strategy is the <span class="term" data-definition="An optimizer is the algorithm that decides how to update a neural network's parameters after each training step. It's the 'navigator' that uses gradient information to decide: 'move this parameter up a little, that one down a lot.' Different optimizers use different navigation strategies.">optimizer</span>.</p>
+        <p>Most AI systems use one optimizer for everything. Autoresearch uses a <em>hybrid</em> &mdash; two different strategies combined into one, each applied to the type of parameter it works best on.</p>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Two Optimizers, One System</h2>
+
+        <div class="pattern-cards animate-in">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">M</div>
+            <h4 class="pattern-title">Muon</h4>
+            <p class="pattern-desc">For the big matrix parameters (attention, MLP weights). Uses a fancy math trick called "orthogonalization" &mdash; imagine straightening all the learning directions so they don't interfere with each other.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">A</div>
+            <h4 class="pattern-title">AdamW</h4>
+            <p class="pattern-desc">For everything else (embeddings, scaling factors, biases). The industry workhorse &mdash; tracks both momentum and variance of gradients to make smooth, stable updates.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-accent animate-in">
+          <div class="callout-icon">&#x1f4a1;</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why Two Optimizers?</strong>
+            <p>Different parameter shapes have different geometry. A 768&times;768 weight matrix lives in a very different mathematical space than a single scaling number. Using the right tool for each shape is like using a screwdriver for screws and a wrench for bolts, instead of hammering everything.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Learning Rate Menu</h2>
+        <p>Not all parameters learn at the same speed. The optimizer assigns different learning rates to different groups, like different speed limits for different road types:</p>
+
+        <div class="badge-list animate-in">
+          <div class="badge-item"><code class="badge-code">0.04</code><span>Transformer matrices (Muon) &mdash; fast learners</span></div>
+          <div class="badge-item"><code class="badge-code">0.6</code><span>Token embeddings (AdamW) &mdash; vocabulary needs lots of tuning</span></div>
+          <div class="badge-item"><code class="badge-code">0.004</code><span>Output head (AdamW) &mdash; initialized near zero, learns gently</span></div>
+          <div class="badge-item"><code class="badge-code">0.5</code><span>Skip-connection weights (AdamW) &mdash; quick-adjusting dials</span></div>
+          <div class="badge-item"><code class="badge-code">0.005</code><span>Residual scales (AdamW) &mdash; per-layer volume, nearly fixed</span></div>
+        </div>
+      </section>
+
+      <!-- Quiz -->
+      <section class="screen animate-in" id="quiz-m5">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <div class="quiz-container">
+          <div class="quiz-question-block" data-question="m5q1" data-correct="b">
+            <h3 class="quiz-question">You're debugging a training run where the model starts learning well but then "forgets" everything after step 200. Which optimizer feature is most likely relevant?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The Muon orthogonalization step</span></button>
+              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The learning rate warmup/cooldown schedule</span></button>
+              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The cautious weight decay mechanism</span></button>
+            </div>
+            <div class="quiz-feedback" data-correct-text="A model that learns then suddenly destabilizes usually has a learning rate problem. The warmup/cooldown schedule ramps the rate up gradually and then reduces it toward the end. If the warmup is wrong, the model can overshoot its sweet spot and diverge." data-incorrect-text="When a model learns well then suddenly 'forgets,' the most common culprit is the learning rate schedule. Too aggressive after warmup and the optimizer overshoots, destroying what it learned."></div>
+          </div>
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m5')">Check Answer</button>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     MODULE 6: WHEN THINGS BREAK
+     ============================================================ -->
+<section class="module" id="module-6" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">06</span>
+      <h1 class="module-title">When Things Break</h1>
+      <p class="module-subtitle">How the system survives crashes, power outages, and GPU meltdowns</p>
+    </header>
+
+    <div class="module-body">
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Problem: 3 AM Crashes</h2>
+        <p>Imagine you start an 80-experiment run before bed. At experiment #47, the cloud provider reboots the machine, or the GPU runs out of memory, or the internet drops. Without protection, you'd lose everything and have to restart from scratch.</p>
+        <p>This system is built like a black box flight recorder &mdash; it survives almost anything.</p>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Defense #1: Atomic Writes</h2>
+        <p>The biggest risk is a half-written results file. If the power dies mid-write, the file could be corrupted. The fix: <span class="term" data-definition="An atomic write is a technique where you write data to a temporary file first, then instantly swap it with the real file using a special operating system command. It's like writing a letter on a fresh sheet, then swapping it onto the stack in one motion &mdash; the stack is never in a half-updated state.">atomic writes</span>.</p>
+
+        <div class="step-cards animate-in">
+          <div class="step-card"><div class="step-num">1</div><div class="step-body"><strong>Write to a temporary file</strong><p>results.tsv.tmp gets the new data</p></div></div>
+          <div class="step-card"><div class="step-num">2</div><div class="step-body"><strong>Force-flush to disk</strong><p><code>fsync()</code> ensures the data is physically written, not just cached</p></div></div>
+          <div class="step-card"><div class="step-num">3</div><div class="step-body"><strong>Atomic rename</strong><p><code>os.replace()</code> swaps the temp file for the real one in a single, uninterruptible operation</p></div></div>
+        </div>
+
+        <div class="callout callout-accent animate-in">
+          <div class="callout-icon">&#x1f4a1;</div>
+          <div class="callout-content">
+            <strong class="callout-title">Atomic Operations Are Everywhere</strong>
+            <p>Every database, every banking system, every app that can't afford to lose data uses this same principle. The operating system guarantees that <code>rename()</code> either fully completes or doesn't happen at all &mdash; there's no in-between. When you tell AI to "save data safely," this is the technique you want it to use.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Defense #2: Heartbeat Monitoring</h2>
+        <p>How do you know if an overnight run is still alive? The system writes a "heartbeat" file every iteration &mdash; like a hospital monitor beeping to show the patient is still breathing.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-keyword">class</span> <span class="code-function">Heartbeat</span>:
+    <span class="code-keyword">def</span> <span class="code-function">update</span>(self, status, experiment, message):
+        data = {
+            <span class="code-string">"status"</span>: status,
+            <span class="code-string">"experiment"</span>: experiment,
+            <span class="code-string">"timestamp"</span>: time.time(),
+            <span class="code-string">"pid"</span>: os.getpid(),
+        }
+        <span class="code-function">atomic_write</span>(self.path, json.dumps(data))</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Create a "heartbeat monitor" object</p>
+              <p class="tl">Every time we finish something, record a pulse:</p>
+              <p class="tl">What are we doing? ("training", "evaluating")</p>
+              <p class="tl">Which experiment number?</p>
+              <p class="tl">Exactly when? (for "how long since last beat?")</p>
+              <p class="tl">Which process is running? (to detect zombies)</p>
+              <p class="tl">Save this pulse using the atomic write technique from before</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Defense #3: Resume from Crash</h2>
+        <p>When the system restarts after a crash, it doesn't start over. It reads the existing results file, finds the last completed experiment, cleans up any half-finished work (like orphaned <span class="term" data-definition="A git commit is a snapshot of your code at a specific moment in time. Like a save point in a video game &mdash; you can always go back to any commit and see exactly what the code looked like at that moment.">git commits</span>), and picks up where it left off.</p>
+      </section>
+
+      <!-- Quiz -->
+      <section class="screen animate-in" id="quiz-m6">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <div class="quiz-container">
+          <div class="quiz-question-block" data-question="m6q1" data-correct="a">
+            <h3 class="quiz-question">Your overnight run crashed at experiment #50. When you restart, the system finds a git commit for "exp50" but no matching row in results.tsv. What should it do?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Revert the orphaned commit and re-run experiment #50</span></button>
+              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Keep the commit and skip to experiment #51</span></button>
+              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Delete results.tsv and start from scratch</span></button>
+            </div>
+            <div class="quiz-feedback" data-correct-text="A commit without a result means the experiment crashed before completing. The system reverts the orphaned commit (cleaning up the mess) and starts fresh from the same experiment number. This is the cleanup logic in _cleanup_interrupted_experiment()." data-incorrect-text="Skipping would leave a gap in the results, and deleting the file would lose all 49 good experiments. The correct approach is to revert the orphaned commit (it represents incomplete work) and re-run experiment #50."></div>
+          </div>
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m6')">Check Answer</button>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     MODULE 7: THE BIG PICTURE
+     ============================================================ -->
+<section class="module" id="module-7" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">07</span>
+      <h1 class="module-title">The Big Picture</h1>
+      <p class="module-subtitle">Zoom out: how four GPU platforms become one unified research machine</p>
+    </header>
+
+    <div class="module-body">
+      <section class="screen animate-in">
+        <h2 class="screen-heading">One Brain, Four Bodies</h2>
+        <p>The real engineering achievement here isn't any single component &mdash; it's that the same experiment can run on an Apple MacBook, an NVIDIA data center GPU, an AMD MI300X, or an Intel Gaudi chip, and the results are directly comparable.</p>
+        <p>Think of it like a recipe that works in any kitchen: gas stove, electric, induction, or campfire. The dish tastes the same because the recipe (the algorithm) is the same &mdash; only the cooking equipment (the GPU) changes.</p>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Architecture, at a Glance</h2>
+        <div class="arch-diagram animate-in" id="arch-main">
+          <div class="arch-zones">
+            <div class="arch-zone">
+              <h4 class="arch-zone-label">Shared Layer (Platform-Agnostic)</h4>
+              <div class="arch-component" data-desc="The brain: proposes experiments, manages the loop, records results. Same code runs everywhere." onclick="showArchDesc(this)"><div class="arch-icon">&#x1f3ac;</div><span>Orchestrator + TUI</span></div>
+              <div class="arch-component" data-desc="Downloads ClimbMix data, trains the BPE tokenizer, provides data loaders. Identical across platforms." onclick="showArchDesc(this)"><div class="arch-icon">&#x1f4e6;</div><span>Data Pipeline (prepare.py)</span></div>
+              <div class="arch-component" data-desc="Analyzes experiments and proposes changes. Same API calls regardless of GPU type." onclick="showArchDesc(this)"><div class="arch-icon">&#x1f916;</div><span>Claude API (llm_backend.py)</span></div>
+              <div class="arch-component" data-desc="Crash-safe results, atomic writes, heartbeat, signal handlers. Shared across all platforms." onclick="showArchDesc(this)"><div class="arch-icon">&#x1f6e1;</div><span>Resilience Layer</span></div>
+            </div>
+            <div class="arch-zone">
+              <h4 class="arch-zone-label">Platform Layer (GPU-Specific)</h4>
+              <div class="arch-component" data-desc="NVIDIA: torch.compile + FlashAttention-2 + CUDA graphs. The fastest platform with 33.7% MFU on RTX PRO 6000." onclick="showArchDesc(this)"><div class="arch-icon" style="color: var(--color-actor-5)">&#x1f7e2;</div><span>CUDA Training</span></div>
+              <div class="arch-component" data-desc="AMD MI300X: CK attention kernels + Triton fusion. 192 GB VRAM but 7.1% MFU (torch.compile disabled due to Inductor crash)." onclick="showArchDesc(this)"><div class="arch-icon" style="color: var(--color-actor-1)">&#x1f534;</div><span>ROCm Training</span></div>
+              <div class="arch-component" data-desc="Apple Silicon: Native MLX framework (not PyTorch). Runs on MacBook Pro. Lower throughput but zero cloud cost." onclick="showArchDesc(this)"><div class="arch-icon" style="color: var(--color-actor-2)">&#x1f535;</div><span>MLX Training</span></div>
+              <div class="arch-component" data-desc="Intel Gaudi 3: Specialized AI chip with 128 GB HBM. Uses Habana's FusedSDPA for attention." onclick="showArchDesc(this)"><div class="arch-icon" style="color: var(--color-actor-3)">&#x1f7e3;</div><span>Gaudi HPU Training</span></div>
+            </div>
+          </div>
+          <div class="arch-description" id="arch-main-desc">Click any component to learn what it does</div>
+        </div>
+      </section>
+
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What You Can Do Now</h2>
+        <p>You've just learned how a real, production AI research system works from the inside. Here's what this knowledge unlocks:</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1); --stagger-index:0">
+            <h4 class="pattern-title">Steer AI Agents Better</h4>
+            <p class="pattern-desc">You can now say "use a dispatcher pattern" instead of "make it work on different computers." Precise vocabulary = precise results.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2); --stagger-index:1">
+            <h4 class="pattern-title">Debug Smarter</h4>
+            <p class="pattern-desc">When something breaks, you know to check: Is it the data? The model? The optimizer? The platform layer? You can narrow down problems systematically.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5); --stagger-index:2">
+            <h4 class="pattern-title">Make Architecture Decisions</h4>
+            <p class="pattern-desc">Dispatcher pattern vs. monolith. Atomic writes vs. hope-for-the-best. Hybrid optimizers vs. one-size-fits-all. You have the vocabulary to choose wisely.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Final Quiz -->
+      <section class="screen animate-in" id="quiz-m7">
+        <h2 class="screen-heading">Final Challenge</h2>
+        <div class="quiz-container">
+          <div class="quiz-question-block" data-question="m7q1" data-correct="c">
+            <div class="scenario-block">
+              <span class="scenario-label">Scenario</span>
+              <p>You're setting up autoresearch on a new AMD MI300X machine and the training runs are 4.7x slower than the same experiments on NVIDIA. You check the logs and see "torch.compile disabled." What's happening?</p>
+            </div>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>AMD GPUs are inherently 4.7x slower than NVIDIA</span></button>
+              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The model architecture is different on ROCm</span></button>
+              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The PyTorch Inductor compiler backend crashes on ROCm, so the system falls back to unoptimized execution</span></button>
+            </div>
+            <div class="quiz-feedback" data-correct-text="You nailed it! This is a real issue in the codebase right now. torch.compile with the Inductor backend crashes on ROCm, so the system falls back to eager mode (7.1% MFU vs 33.7% on CUDA). The fix is being tracked as a PR." data-incorrect-text="The MI300X is actually very powerful hardware. The 4.7x gap comes from torch.compile being disabled on ROCm due to an Inductor backend crash &mdash; the system falls back to unoptimized execution. This is a real, active issue in the codebase."></div>
+          </div>
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m7')">Check Answer</button>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     JAVASCRIPT
+     ============================================================ -->
+<script>
+(function() {
+  'use strict';
+
+  // ========== SCROLL & NAV ==========
+  const progressBar = document.getElementById('progress-bar');
+  const navDots = document.querySelectorAll('.nav-dot');
+  const modules = document.querySelectorAll('.module');
+
+  function updateProgress() {
+    const scrollTop = window.scrollY;
+    const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+    const progress = scrollHeight > 0 ? (scrollTop / scrollHeight) * 100 : 0;
+    progressBar.style.width = progress + '%';
+
+    // Update nav dots
+    let currentIdx = 0;
+    modules.forEach((mod, i) => {
+      const rect = mod.getBoundingClientRect();
+      if (rect.top <= window.innerHeight / 3) currentIdx = i;
+    });
+    navDots.forEach((dot, i) => {
+      dot.classList.remove('active');
+      if (i < currentIdx) dot.classList.add('visited');
+      if (i === currentIdx) dot.classList.add('active');
+    });
+  }
+  window.addEventListener('scroll', () => requestAnimationFrame(updateProgress), { passive: true });
+
+  navDots.forEach(dot => {
+    dot.addEventListener('click', () => {
+      const target = document.getElementById(dot.dataset.target);
+      if (target) target.scrollIntoView({ behavior: 'smooth' });
+    });
+  });
+
+  // Keyboard nav
+  document.addEventListener('keydown', (e) => {
+    if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
+    const modArray = Array.from(modules);
+    let current = 0;
+    modArray.forEach((m, i) => { if (m.getBoundingClientRect().top <= 100) current = i; });
+    if ((e.key === 'ArrowDown' || e.key === 'ArrowRight') && current < modArray.length - 1) {
+      modArray[current + 1].scrollIntoView({ behavior: 'smooth' }); e.preventDefault();
+    }
+    if ((e.key === 'ArrowUp' || e.key === 'ArrowLeft') && current > 0) {
+      modArray[current - 1].scrollIntoView({ behavior: 'smooth' }); e.preventDefault();
+    }
+  });
+
+  // ========== SCROLL REVEAL ==========
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) { entry.target.classList.add('visible'); observer.unobserve(entry.target); }
+    });
+  }, { rootMargin: '0px 0px -10% 0px', threshold: 0.1 });
+  document.querySelectorAll('.animate-in').forEach(el => observer.observe(el));
+
+  // Stagger
+  document.querySelectorAll('.stagger-children').forEach(parent => {
+    Array.from(parent.children).forEach((child, i) => {
+      if (!child.style.getPropertyValue('--stagger-index')) child.style.setProperty('--stagger-index', i);
+    });
+  });
+
+  // ========== TRAINING FLOW ==========
+  const ftSteps = [
+    { highlight: 'ft-data', label: 'Data Loader reads text from ClimbMix parquet files and packs it into batches' },
+    { highlight: 'ft-model', label: 'Neural network processes the batch: embedding → attention → MLP → output' },
+    { highlight: 'ft-model', label: 'Model predicts the next word, compares to the real answer, and calculates the "loss" (error)' },
+    { highlight: 'ft-optim', label: 'Optimizer reads the loss gradient and adjusts all parameters to reduce the error' },
+    { highlight: 'ft-data', label: 'Loop! Load next batch. Repeat hundreds of times in 5 minutes.' },
+    { highlight: 'ft-eval', label: 'Time\'s up! Evaluator measures val_bpb on held-out text to see how well the model learned.' },
+  ];
+  let ftStep = 0;
+  window.ftNext = function() {
+    if (ftStep >= ftSteps.length) return;
+    const s = ftSteps[ftStep];
+    document.querySelectorAll('#flow-training .flow-actor').forEach(a => a.classList.remove('active'));
+    document.getElementById(s.highlight).classList.add('active');
+    document.getElementById('ft-label').textContent = s.label;
+    ftStep++;
+    document.getElementById('ft-progress').textContent = 'Step ' + ftStep + ' / ' + ftSteps.length;
+  };
+  window.ftReset = function() {
+    ftStep = 0;
+    document.querySelectorAll('#flow-training .flow-actor').forEach(a => a.classList.remove('active'));
+    document.getElementById('ft-label').textContent = 'Click "Next Step" to see the training loop';
+    document.getElementById('ft-progress').textContent = 'Step 0 / ' + ftSteps.length;
+  };
+
+  // ========== CHAT ANIMATION ==========
+  const chats = {};
+  function initChat(id) {
+    const msgs = document.querySelectorAll('#chat-' + id + '-msgs .chat-message');
+    chats[id] = { msgs, index: 0 };
+  }
+  initChat('cast');
+
+  const chatActors = {
+    'orch': { initials: 'O', color: 'var(--color-actor-1)' },
+    'claude': { initials: 'C', color: 'var(--color-actor-2)' },
+    'trainer': { initials: 'T', color: 'var(--color-actor-3)' },
+    'git': { initials: 'G', color: 'var(--color-actor-4)' },
+    'results': { initials: 'R', color: 'var(--color-actor-5)' },
+  };
+
+  window.playChatNext = function(id) {
+    const c = chats[id]; if (!c || c.index >= c.msgs.length) return;
+    const msg = c.msgs[c.index];
+    const sender = msg.dataset.sender;
+    const typing = document.getElementById('chat-' + id + '-typing');
+    const avatar = document.getElementById(id + '-typing-avatar');
+    if (chatActors[sender]) {
+      avatar.textContent = chatActors[sender].initials;
+      avatar.style.background = chatActors[sender].color;
+    }
+    typing.style.display = 'flex';
+    setTimeout(() => {
+      typing.style.display = 'none';
+      msg.style.display = 'flex';
+      msg.style.animation = 'fadeSlideUp 0.3s var(--ease-out)';
+      c.index++;
+      document.getElementById('chat-' + id + '-progress').textContent = c.index + ' / ' + c.msgs.length + ' messages';
+      // Auto-scroll
+      const container = document.getElementById('chat-' + id + '-msgs');
+      container.scrollTop = container.scrollHeight;
+    }, 800);
+  };
+
+  window.playChatAll = function(id) {
+    const c = chats[id]; if (!c) return;
+    const interval = setInterval(() => {
+      if (c.index >= c.msgs.length) { clearInterval(interval); return; }
+      playChatNext(id);
+    }, 1400);
+  };
+
+  window.resetChat = function(id) {
+    const c = chats[id]; if (!c) return;
+    c.index = 0;
+    c.msgs.forEach(m => { m.style.display = 'none'; m.style.animation = ''; });
+    document.getElementById('chat-' + id + '-progress').textContent = '0 / ' + c.msgs.length + ' messages';
+  };
+
+  // ========== QUIZ ==========
+  window.selectOption = function(btn) {
+    const block = btn.closest('.quiz-question-block');
+    block.querySelectorAll('.quiz-option').forEach(o => o.classList.remove('selected'));
+    btn.classList.add('selected');
+  };
+
+  window.checkQuiz = function(sectionId) {
+    const container = document.getElementById(sectionId);
+    const questions = container.querySelectorAll('.quiz-question-block');
+    questions.forEach(q => {
+      const selected = q.querySelector('.quiz-option.selected');
+      const feedback = q.querySelector('.quiz-feedback');
+      const correctValue = q.dataset.correct;
+      if (!selected) { feedback.innerHTML = 'Pick an answer first!'; feedback.className = 'quiz-feedback show error'; return; }
+      if (selected.dataset.value === correctValue) {
+        selected.classList.add('correct');
+        feedback.innerHTML = '<strong>Exactly!</strong> ' + feedback.dataset.correctText;
+        feedback.className = 'quiz-feedback show success';
+      } else {
+        selected.classList.add('incorrect');
+        q.querySelector('[data-value="' + correctValue + '"]').classList.add('correct');
+        feedback.innerHTML = '<strong>Not quite.</strong> ' + feedback.dataset.incorrectText;
+        feedback.className = 'quiz-feedback show error';
+      }
+      q.querySelectorAll('.quiz-option').forEach(o => { o.style.pointerEvents = 'none'; });
+    });
+  };
+
+  // ========== ARCH DIAGRAM ==========
+  window.showArchDesc = function(el) {
+    document.querySelectorAll('.arch-component').forEach(c => c.classList.remove('selected'));
+    el.classList.add('selected');
+    const desc = el.closest('.arch-diagram').querySelector('.arch-description');
+    desc.textContent = el.dataset.desc;
+    desc.style.background = 'var(--color-accent-light)';
+    desc.style.color = 'var(--color-text)';
+  };
+
+  // ========== GLOSSARY TOOLTIPS ==========
+  let activeTooltip = null;
+  function positionTooltip(term, tip) {
+    const rect = term.getBoundingClientRect();
+    const tipWidth = Math.min(320, window.innerWidth * 0.8);
+    tip.style.width = tipWidth + 'px';
+    let left = rect.left + rect.width / 2 - tipWidth / 2;
+    left = Math.max(8, Math.min(left, window.innerWidth - tipWidth - 8));
+    tip.style.left = left + 'px';
+    document.body.appendChild(tip);
+    const tipHeight = tip.offsetHeight;
+    if (rect.top - tipHeight - 8 < 0) {
+      tip.style.top = (rect.bottom + 8) + 'px';
+      tip.classList.add('flip');
+    } else {
+      tip.style.top = (rect.top - tipHeight - 8) + 'px';
+      tip.classList.remove('flip');
+    }
+  }
+
+  document.querySelectorAll('.term').forEach(term => {
+    const tip = document.createElement('span');
+    tip.className = 'term-tooltip';
+    tip.textContent = term.dataset.definition;
+
+    term.addEventListener('mouseenter', () => {
+      if (activeTooltip && activeTooltip !== tip) { activeTooltip.classList.remove('visible'); activeTooltip.remove(); }
+      positionTooltip(term, tip);
+      requestAnimationFrame(() => tip.classList.add('visible'));
+      activeTooltip = tip;
+    });
+    term.addEventListener('mouseleave', () => {
+      tip.classList.remove('visible');
+      setTimeout(() => { if (!tip.classList.contains('visible')) tip.remove(); }, 150);
+      activeTooltip = null;
+    });
+    term.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (activeTooltip && activeTooltip !== tip) { activeTooltip.classList.remove('visible'); activeTooltip.remove(); }
+      if (tip.classList.contains('visible')) { tip.classList.remove('visible'); tip.remove(); activeTooltip = null; }
+      else { positionTooltip(term, tip); requestAnimationFrame(() => tip.classList.add('visible')); activeTooltip = tip; }
+    });
+  });
+  document.addEventListener('click', () => {
+    if (activeTooltip) { activeTooltip.classList.remove('visible'); activeTooltip.remove(); activeTooltip = null; }
+  });
+
+  // Initial update
+  updateProgress();
+})();
+</script>
+
+<footer class="site-footer">
+  <a href="https://github.com/elementalcollision/autoresearch-unified">GitHub</a>
+  <a href="https://huggingface.co/datasets/davegraham/autoresearch-experiments">HuggingFace</a>
+  <a href="https://github.com/elementalcollision/autoresearch-unified/wiki">Wiki</a>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,1433 +3,167 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>How Autoresearch Works — An Interactive Course</title>
+<title>autoresearch-unified</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400;1,9..40,500&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="shared.css">
 <style>
-/* ============================================================
-   DESIGN SYSTEM
-   ============================================================ */
-:root {
-  --color-bg:             #FAF7F2;
-  --color-bg-warm:        #F5F0E8;
-  --color-bg-code:        #1E1E2E;
-  --color-text:           #2C2A28;
-  --color-text-secondary: #6B6560;
-  --color-text-muted:     #9E9790;
-  --color-border:         #E5DFD6;
-  --color-border-light:   #EEEBE5;
-  --color-surface:        #FFFFFF;
-  --color-surface-warm:   #FDF9F3;
-  --color-accent:         #D94F30;
-  --color-accent-hover:   #C4432A;
-  --color-accent-light:   #FDEEE9;
-  --color-accent-muted:   #E8836C;
-  --color-success:        #2D8B55;
-  --color-success-light:  #E8F5EE;
-  --color-error:          #C93B3B;
-  --color-error-light:    #FDE8E8;
-  --color-info:           #2A7B9B;
-  --color-info-light:     #E4F2F7;
-  --color-actor-1:        #D94F30;
-  --color-actor-2:        #2A7B9B;
-  --color-actor-3:        #7B6DAA;
-  --color-actor-4:        #D4A843;
-  --color-actor-5:        #2D8B55;
-  --font-display:  'Bricolage Grotesque', Georgia, serif;
-  --font-body:     'DM Sans', -apple-system, sans-serif;
-  --font-mono:     'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
-  --text-xs:   0.75rem;
-  --text-sm:   0.875rem;
-  --text-base: 1rem;
-  --text-lg:   1.125rem;
-  --text-xl:   1.25rem;
-  --text-2xl:  1.5rem;
-  --text-3xl:  1.875rem;
-  --text-4xl:  2.25rem;
-  --text-5xl:  3rem;
-  --text-6xl:  3.75rem;
-  --leading-tight:  1.15;
-  --leading-snug:   1.3;
-  --leading-normal: 1.6;
-  --leading-loose:  1.8;
-  --space-1:  0.25rem;
-  --space-2:  0.5rem;
-  --space-3:  0.75rem;
-  --space-4:  1rem;
-  --space-5:  1.25rem;
-  --space-6:  1.5rem;
-  --space-8:  2rem;
-  --space-10: 2.5rem;
-  --space-12: 3rem;
-  --space-16: 4rem;
-  --space-20: 5rem;
-  --space-24: 6rem;
-  --content-width:     800px;
-  --content-width-wide: 1000px;
-  --nav-height:        50px;
-  --radius-sm:  8px;
-  --radius-md:  12px;
-  --radius-lg:  16px;
-  --radius-full: 9999px;
-  --shadow-sm:  0 1px 2px rgba(44,42,40,0.05);
-  --shadow-md:  0 4px 12px rgba(44,42,40,0.08);
-  --shadow-lg:  0 8px 24px rgba(44,42,40,0.1);
-  --shadow-xl:  0 16px 48px rgba(44,42,40,0.12);
-  --ease-out:    cubic-bezier(0.16, 1, 0.3, 1);
-  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
-  --duration-fast:   150ms;
-  --duration-normal: 300ms;
-  --duration-slow:   500ms;
-  --stagger-delay:   120ms;
-}
-
-/* ============================================================
-   RESET & BASE
-   ============================================================ */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html { scroll-snap-type: y proximity; scroll-behavior: smooth; }
 body {
-  font-family: var(--font-body);
-  font-size: var(--text-base);
-  line-height: var(--leading-normal);
-  color: var(--color-text);
-  background: var(--color-bg);
-  background-image: radial-gradient(ellipse at 20% 50%, rgba(217,79,48,0.03) 0%, transparent 50%);
-  -webkit-font-smoothing: antialiased;
-}
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: var(--radius-full); }
-pre, code { white-space: pre-wrap; word-break: break-word; overflow-x: hidden; }
-a { color: var(--color-accent); text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-/* ============================================================
-   NAV
-   ============================================================ */
-.nav {
-  position: fixed; top: 0; left: 0; right: 0; z-index: 1000;
-  background: rgba(250,247,242,0.92); backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--color-border-light);
-  height: var(--nav-height);
-}
-.progress-bar {
-  position: absolute; top: 0; left: 0; height: 3px;
-  background: var(--color-accent); width: 0%; transition: width 100ms linear;
-}
-.nav-inner {
-  max-width: var(--content-width-wide); margin: 0 auto;
-  display: flex; align-items: center; justify-content: space-between;
-  height: 100%; padding: 0 var(--space-6);
-}
-.nav-title { font-family: var(--font-display); font-weight: 700; font-size: var(--text-sm); color: var(--color-text); }
-.nav-dots { display: flex; gap: var(--space-3); }
-.nav-dot {
-  width: 12px; height: 12px; border-radius: 50%;
-  border: 2px solid var(--color-text-muted); background: transparent;
-  cursor: pointer; transition: all var(--duration-fast);
-  position: relative; padding: 0;
-}
-.nav-dot:hover { border-color: var(--color-accent); }
-.nav-dot.active { border-color: var(--color-accent); background: var(--color-accent); box-shadow: 0 0 8px rgba(217,79,48,0.3); }
-.nav-dot.visited { background: var(--color-accent); border-color: var(--color-accent); }
-.nav-dot[data-tooltip]:hover::after {
-  content: attr(data-tooltip); position: absolute; top: calc(100% + 8px); left: 50%;
-  transform: translateX(-50%); background: var(--color-bg-code); color: #CDD6F4;
-  padding: var(--space-1) var(--space-3); border-radius: var(--radius-sm);
-  font-size: var(--text-xs); white-space: nowrap; pointer-events: none; z-index: 1001;
+  font-family: 'DM Sans', -apple-system, sans-serif;
+  background: #FAF7F2;
+  color: #2C2A28;
+  min-height: 100vh;
+  padding-top: 50px;
 }
 
-/* ============================================================
-   MODULE LAYOUT
-   ============================================================ */
-.module {
-  min-height: 100dvh; min-height: 100vh;
-  scroll-snap-align: start;
-  padding: var(--space-16) var(--space-6);
-  padding-top: calc(var(--nav-height) + var(--space-12));
+.hero {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 4rem 2rem 2rem;
+  text-align: center;
 }
-.module-content { max-width: var(--content-width); margin: 0 auto; }
-.module-header { margin-bottom: var(--space-12); }
-.module-number {
-  font-family: var(--font-display); font-size: var(--text-6xl); font-weight: 800;
-  color: var(--color-accent); opacity: 0.15; line-height: 1; display: block;
-  margin-bottom: var(--space-2);
+.hero h1 {
+  font-family: 'Bricolage Grotesque', Georgia, serif;
+  font-size: 2.5rem;
+  font-weight: 800;
+  line-height: 1.15;
+  margin-bottom: 0.75rem;
 }
-.module-title {
-  font-family: var(--font-display); font-size: var(--text-4xl); font-weight: 700;
-  line-height: var(--leading-tight); margin-bottom: var(--space-3);
-}
-.module-subtitle {
-  font-size: var(--text-lg); color: var(--color-text-secondary);
-  line-height: var(--leading-snug);
-}
-.screen { margin-bottom: var(--space-16); }
-.screen-heading {
-  font-family: var(--font-display); font-size: var(--text-2xl); font-weight: 600;
-  margin-bottom: var(--space-6); line-height: var(--leading-snug);
-}
-.screen p { margin-bottom: var(--space-4); max-width: 65ch; }
-
-/* ============================================================
-   ANIMATIONS
-   ============================================================ */
-.animate-in { opacity: 0; transform: translateY(20px); transition: opacity var(--duration-slow) var(--ease-out), transform var(--duration-slow) var(--ease-out); }
-.animate-in.visible { opacity: 1; transform: translateY(0); }
-.stagger-children > .animate-in { transition-delay: calc(var(--stagger-index, 0) * var(--stagger-delay)); }
-@keyframes fadeSlideUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
-@keyframes typingBounce { 0%, 60%, 100% { transform: translateY(0); } 30% { transform: translateY(-6px); } }
-@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
-@keyframes packetMove { 0% { left: var(--from-x); top: var(--from-y); opacity: 1; } 100% { left: var(--to-x); top: var(--to-y); opacity: 1; } }
-
-/* ============================================================
-   TRANSLATION BLOCKS
-   ============================================================ */
-.translation-block {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
-  border-radius: var(--radius-md); overflow: hidden;
-  box-shadow: var(--shadow-md); margin: var(--space-8) 0;
-}
-.translation-code {
-  background: var(--color-bg-code); color: #CDD6F4;
-  padding: var(--space-6); font-family: var(--font-mono);
-  font-size: var(--text-sm); line-height: 1.7; position: relative;
-  overflow-x: hidden;
-}
-.translation-code pre, .translation-code code { white-space: pre-wrap; word-break: break-word; overflow-x: hidden; }
-.translation-english {
-  background: var(--color-surface-warm); padding: var(--space-6);
-  font-size: var(--text-sm); line-height: 1.7;
-  border-left: 3px solid var(--color-accent);
-}
-.translation-label {
-  position: absolute; top: var(--space-2); right: var(--space-3);
-  font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.1em; opacity: 0.5;
-}
-.translation-english .translation-label { color: var(--color-text-muted); position: relative; top: auto; right: auto; display: block; margin-bottom: var(--space-3); }
-.tl { margin-bottom: var(--space-3); padding-left: var(--space-3); border-left: 2px solid var(--color-border-light); }
-.code-keyword  { color: #CBA6F7; }
-.code-string   { color: #A6E3A1; }
-.code-function { color: #89B4FA; }
-.code-comment  { color: #6C7086; }
-.code-number   { color: #FAB387; }
-.code-property { color: #F9E2AF; }
-.code-operator { color: #94E2D5; }
-
-/* ============================================================
-   CALLOUT BOXES
-   ============================================================ */
-.callout {
-  display: flex; gap: var(--space-4); padding: var(--space-5) var(--space-6);
-  border-radius: var(--radius-md); margin: var(--space-8) 0;
-}
-.callout-accent { background: var(--color-accent-light); border-left: 4px solid var(--color-accent); }
-.callout-info { background: var(--color-info-light); border-left: 4px solid var(--color-info); }
-.callout-warning { background: var(--color-error-light); border-left: 4px solid var(--color-error); }
-.callout-icon { font-size: 1.5rem; flex-shrink: 0; }
-.callout-title { display: block; font-weight: 600; margin-bottom: var(--space-1); font-family: var(--font-display); }
-.callout-content p { margin-bottom: var(--space-2); font-size: var(--text-sm); }
-
-/* ============================================================
-   PATTERN CARDS
-   ============================================================ */
-.pattern-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--space-4); margin: var(--space-8) 0; }
-.pattern-card {
-  background: var(--color-surface); border-radius: var(--radius-md);
-  padding: var(--space-6); box-shadow: var(--shadow-sm);
-  transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal);
-}
-.pattern-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
-.pattern-icon { width: 40px; height: 40px; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: 1.25rem; margin-bottom: var(--space-3); color: white; }
-.pattern-title { font-family: var(--font-display); font-weight: 600; margin-bottom: var(--space-2); }
-.pattern-desc { font-size: var(--text-sm); color: var(--color-text-secondary); }
-
-/* ============================================================
-   ICON ROWS
-   ============================================================ */
-.icon-rows { display: flex; flex-direction: column; gap: var(--space-4); margin: var(--space-8) 0; }
-.icon-row {
-  display: flex; align-items: center; gap: var(--space-4);
-  padding: var(--space-4); background: var(--color-surface);
-  border-radius: var(--radius-md); box-shadow: var(--shadow-sm);
-}
-.icon-row p { margin: 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
-.icon-circle {
-  width: 48px; height: 48px; border-radius: 50%;
-  display: flex; align-items: center; justify-content: center;
-  font-size: 1.25rem; flex-shrink: 0; color: white;
+.hero p {
+  color: #6B6560;
+  font-size: 1.125rem;
+  line-height: 1.6;
+  max-width: 560px;
+  margin: 0 auto;
 }
 
-/* ============================================================
-   STEP CARDS
-   ============================================================ */
-.step-cards { display: flex; flex-direction: column; gap: var(--space-3); margin: var(--space-8) 0; }
-.step-card {
-  display: flex; align-items: flex-start; gap: var(--space-4);
-  padding: var(--space-4) var(--space-5); background: var(--color-surface);
-  border-radius: var(--radius-md); border-left: 3px solid var(--color-accent);
-  box-shadow: var(--shadow-sm);
-}
-.step-num {
-  width: 32px; height: 32px; border-radius: 50%;
-  background: var(--color-accent); color: white; font-weight: 700;
-  display: flex; align-items: center; justify-content: center;
-  font-family: var(--font-display); flex-shrink: 0;
-}
-.step-body p { margin: var(--space-1) 0 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
-
-/* ============================================================
-   FILE TREE
-   ============================================================ */
-.file-tree { font-family: var(--font-mono); font-size: var(--text-sm); margin: var(--space-8) 0; background: var(--color-surface); padding: var(--space-6); border-radius: var(--radius-md); box-shadow: var(--shadow-sm); }
-.ft-folder, .ft-file { padding: var(--space-2) var(--space-3); border-left: 2px solid var(--color-border-light); margin-left: var(--space-4); }
-.ft-folder > .ft-name { color: var(--color-accent); font-weight: 600; }
-.ft-file > .ft-name { color: var(--color-text); }
-.ft-desc { color: var(--color-text-secondary); font-family: var(--font-body); margin-left: var(--space-2); font-size: var(--text-xs); }
-.ft-children { margin-left: var(--space-4); }
-
-/* ============================================================
-   CHAT ANIMATION
-   ============================================================ */
-.chat-window {
-  background: var(--color-surface); border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg); overflow: hidden; margin: var(--space-8) 0;
-  border: 1px solid var(--color-border-light);
-}
-.chat-header { background: var(--color-bg-code); color: #CDD6F4; padding: var(--space-3) var(--space-5); font-family: var(--font-mono); font-size: var(--text-sm); font-weight: 600; }
-.chat-messages { padding: var(--space-5); min-height: 200px; max-height: 450px; overflow-y: auto; display: flex; flex-direction: column; gap: var(--space-4); }
-.chat-message { display: flex; gap: var(--space-3); align-items: flex-start; }
-.chat-avatar { width: 36px; height: 36px; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: white; font-weight: 700; font-size: var(--text-sm); font-family: var(--font-mono); flex-shrink: 0; }
-.chat-bubble { background: var(--color-bg); padding: var(--space-3) var(--space-4); border-radius: var(--radius-md); max-width: 80%; }
-.chat-sender { font-weight: 600; font-size: var(--text-xs); display: block; margin-bottom: var(--space-1); text-transform: uppercase; letter-spacing: 0.05em; }
-.chat-bubble p { font-size: var(--text-sm); margin: 0; }
-.chat-typing { display: flex; gap: var(--space-3); align-items: center; padding: 0 var(--space-5) var(--space-3); }
-.chat-typing-dots { display: flex; gap: 4px; }
-.typing-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--color-text-muted); animation: typingBounce 1.4s infinite; }
-.typing-dot:nth-child(2) { animation-delay: 0.2s; }
-.typing-dot:nth-child(3) { animation-delay: 0.4s; }
-.chat-controls { display: flex; gap: var(--space-3); padding: var(--space-3) var(--space-5); border-top: 1px solid var(--color-border-light); align-items: center; flex-wrap: wrap; }
-.chat-controls button {
-  padding: var(--space-2) var(--space-4); border: 1px solid var(--color-border);
-  border-radius: var(--radius-full); background: var(--color-surface);
-  cursor: pointer; font-family: var(--font-body); font-size: var(--text-sm);
-  transition: all var(--duration-fast);
-}
-.chat-controls button:hover { border-color: var(--color-accent); color: var(--color-accent); }
-.chat-progress { font-size: var(--text-xs); color: var(--color-text-muted); margin-left: auto; }
-
-/* ============================================================
-   FLOW ANIMATION
-   ============================================================ */
-.flow-animation {
-  background: var(--color-surface); border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg); padding: var(--space-8); margin: var(--space-8) 0;
-  position: relative; overflow: hidden;
-}
-.flow-actors { display: flex; justify-content: space-around; gap: var(--space-4); flex-wrap: wrap; margin-bottom: var(--space-8); }
-.flow-actor { text-align: center; transition: all var(--duration-normal) var(--ease-out); padding: var(--space-3); border-radius: var(--radius-md); }
-.flow-actor-icon {
-  width: 56px; height: 56px; border-radius: 50%; display: flex; align-items: center; justify-content: center;
-  color: white; font-weight: 700; font-size: 1.25rem; margin: 0 auto var(--space-2);
-  font-family: var(--font-mono); transition: all var(--duration-normal);
-}
-.flow-actor span { font-size: var(--text-sm); font-weight: 500; }
-.flow-actor.active { background: var(--color-accent-light); }
-.flow-actor.active .flow-actor-icon { box-shadow: 0 0 0 3px var(--color-accent), 0 0 20px rgba(217,79,48,0.2); transform: scale(1.1); }
-.flow-step-label {
-  text-align: center; font-size: var(--text-lg); font-weight: 500;
-  min-height: 60px; display: flex; align-items: center; justify-content: center;
-  padding: var(--space-4); background: var(--color-bg); border-radius: var(--radius-md);
-  margin-bottom: var(--space-6); transition: all var(--duration-normal);
-}
-.flow-controls { display: flex; gap: var(--space-3); justify-content: center; align-items: center; flex-wrap: wrap; }
-.flow-controls button {
-  padding: var(--space-2) var(--space-5); border: 2px solid var(--color-accent);
-  border-radius: var(--radius-full); background: transparent; color: var(--color-accent);
-  cursor: pointer; font-family: var(--font-body); font-weight: 600; font-size: var(--text-sm);
-  transition: all var(--duration-fast);
-}
-.flow-controls button:hover { background: var(--color-accent); color: white; }
-.flow-progress { font-size: var(--text-xs); color: var(--color-text-muted); }
-
-/* ============================================================
-   QUIZ
-   ============================================================ */
-.quiz-container { margin: var(--space-8) 0; }
-.quiz-question-block { margin-bottom: var(--space-8); }
-.quiz-question { font-family: var(--font-display); font-weight: 600; margin-bottom: var(--space-4); font-size: var(--text-lg); }
-.quiz-options { display: flex; flex-direction: column; gap: var(--space-2); }
-.quiz-option {
-  display: flex; align-items: center; gap: var(--space-3);
-  padding: var(--space-3) var(--space-4); border: 2px solid var(--color-border);
-  border-radius: var(--radius-sm); background: var(--color-surface);
-  cursor: pointer; width: 100%; transition: border-color var(--duration-fast), background var(--duration-fast);
-  font-family: var(--font-body); font-size: var(--text-sm); text-align: left;
-}
-.quiz-option:hover { border-color: var(--color-accent-muted); }
-.quiz-option.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
-.quiz-option.correct { border-color: var(--color-success); background: var(--color-success-light); }
-.quiz-option.incorrect { border-color: var(--color-error); background: var(--color-error-light); }
-.quiz-option-radio {
-  width: 18px; height: 18px; border-radius: 50%; border: 2px solid var(--color-border);
-  transition: all var(--duration-fast); flex-shrink: 0;
-}
-.quiz-option.selected .quiz-option-radio { border-color: var(--color-accent); background: var(--color-accent); box-shadow: inset 0 0 0 3px white; }
-.quiz-option.correct .quiz-option-radio { border-color: var(--color-success); background: var(--color-success); box-shadow: inset 0 0 0 3px white; }
-.quiz-option.incorrect .quiz-option-radio { border-color: var(--color-error); background: var(--color-error); box-shadow: inset 0 0 0 3px white; }
-.quiz-feedback { max-height: 0; overflow: hidden; opacity: 0; transition: max-height var(--duration-normal), opacity var(--duration-normal), padding var(--duration-normal); border-radius: var(--radius-sm); font-size: var(--text-sm); }
-.quiz-feedback.show { max-height: 200px; opacity: 1; padding: var(--space-3) var(--space-4); margin-top: var(--space-2); }
-.quiz-feedback.success { background: var(--color-success-light); color: var(--color-success); }
-.quiz-feedback.error { background: var(--color-error-light); color: var(--color-error); }
-.quiz-check-btn {
-  margin-top: var(--space-4); padding: var(--space-3) var(--space-8);
-  background: var(--color-accent); color: white; border: none; border-radius: var(--radius-full);
-  font-family: var(--font-display); font-weight: 600; font-size: var(--text-base);
-  cursor: pointer; transition: background var(--duration-fast);
-}
-.quiz-check-btn:hover { background: var(--color-accent-hover); }
-
-/* ============================================================
-   GLOSSARY TOOLTIPS
-   ============================================================ */
-.term { border-bottom: 1.5px dashed var(--color-accent-muted); cursor: pointer; position: relative; }
-.term:hover, .term.active { border-bottom-color: var(--color-accent); color: var(--color-accent); }
-.term-tooltip {
-  position: fixed; background: var(--color-bg-code); color: #CDD6F4;
-  padding: var(--space-3) var(--space-4); border-radius: var(--radius-sm);
-  font-size: var(--text-sm); font-family: var(--font-body); line-height: var(--leading-normal);
-  width: max(200px, min(320px, 80vw)); box-shadow: var(--shadow-lg);
-  pointer-events: none; opacity: 0; transition: opacity var(--duration-fast); z-index: 10000;
-}
-.term-tooltip::after {
-  content: ''; position: absolute; top: 100%; left: 50%; transform: translateX(-50%);
-  border: 6px solid transparent; border-top-color: var(--color-bg-code);
-}
-.term-tooltip.visible { opacity: 1; }
-.term-tooltip.flip::after { top: auto; bottom: 100%; border-top-color: transparent; border-bottom-color: var(--color-bg-code); }
-
-/* ============================================================
-   BADGE LIST
-   ============================================================ */
-.badge-list { display: flex; flex-direction: column; gap: var(--space-2); margin: var(--space-6) 0; }
-.badge-item {
-  display: flex; align-items: center; gap: var(--space-4);
-  padding: var(--space-3) var(--space-4); border: 1px solid var(--color-border-light);
-  border-radius: var(--radius-sm); transition: border-color var(--duration-fast);
-}
-.badge-item:hover { border-color: var(--color-accent-muted); }
-.badge-code {
-  font-family: var(--font-mono); font-size: var(--text-sm);
-  background: var(--color-bg-code); color: #CBA6F7;
-  padding: var(--space-1) var(--space-3); border-radius: var(--radius-sm); white-space: nowrap;
+.cards {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1.5rem 2rem 4rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
 }
 
-/* ============================================================
-   SCENARIO BLOCK
-   ============================================================ */
-.scenario-block { background: var(--color-surface-warm); border-radius: var(--radius-md); padding: var(--space-5) var(--space-6); margin: var(--space-6) 0; border: 1px solid var(--color-border-light); }
-.scenario-label { font-size: var(--text-xs); font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-accent); font-weight: 600; display: block; margin-bottom: var(--space-2); }
-.scenario-block > p { font-size: var(--text-sm); color: var(--color-text-secondary); margin-bottom: var(--space-4); }
-
-/* ============================================================
-   ARCH DIAGRAM
-   ============================================================ */
-.arch-diagram { background: var(--color-surface); border-radius: var(--radius-lg); box-shadow: var(--shadow-md); padding: var(--space-6); margin: var(--space-8) 0; }
-.arch-zones { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); margin-bottom: var(--space-6); }
-.arch-zone { padding: var(--space-4); border-radius: var(--radius-md); border: 2px dashed var(--color-border); }
-.arch-zone-label { font-family: var(--font-mono); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-text-muted); margin-bottom: var(--space-3); }
-.arch-component {
-  display: flex; align-items: center; gap: var(--space-3);
-  padding: var(--space-3); border-radius: var(--radius-sm);
-  cursor: pointer; transition: all var(--duration-fast);
-  border: 1px solid transparent;
+.card {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+  background: #FFFFFF;
+  border: 2px solid #E5DFD6;
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: all 150ms cubic-bezier(0.16, 1, 0.3, 1);
 }
-.arch-component:hover { border-color: var(--color-accent); background: var(--color-accent-light); }
-.arch-component.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
-.arch-icon { font-size: 1.25rem; }
-.arch-component span { font-size: var(--text-sm); font-weight: 500; }
-.arch-description { padding: var(--space-4); background: var(--color-bg); border-radius: var(--radius-sm); font-size: var(--text-sm); color: var(--color-text-secondary); min-height: 50px; text-align: center; }
-
-/* ============================================================
-   RESPONSIVE
-   ============================================================ */
-@media (max-width: 768px) {
-  :root { --text-4xl: 1.875rem; --text-5xl: 2.25rem; --text-6xl: 3rem; }
-  .translation-block { grid-template-columns: 1fr; }
-  .translation-english { border-left: none; border-top: 3px solid var(--color-accent); }
-  .pattern-cards { grid-template-columns: 1fr 1fr; }
-  .arch-zones { grid-template-columns: 1fr; }
-  .flow-actors { gap: var(--space-2); }
-}
-@media (max-width: 480px) {
-  :root { --text-4xl: 1.5rem; --text-5xl: 1.875rem; --text-6xl: 2.25rem; }
-  .module { padding: var(--space-8) var(--space-4); }
-  .pattern-cards { grid-template-columns: 1fr; }
+.card:hover {
+  border-color: #2A7B9B;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(44, 42, 40, 0.1);
+  text-decoration: none;
+  color: inherit;
 }
 
-/* ============================================================
-   HERO
-   ============================================================ */
-.hero-module { display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
-.hero-module .module-header { text-align: center; }
-.hero-badge { display: inline-block; padding: var(--space-1) var(--space-4); background: var(--color-accent-light); color: var(--color-accent); border-radius: var(--radius-full); font-size: var(--text-sm); font-weight: 600; margin-bottom: var(--space-6); font-family: var(--font-mono); }
-.hero-title { font-family: var(--font-display); font-size: var(--text-5xl); font-weight: 800; line-height: var(--leading-tight); margin-bottom: var(--space-6); }
-.hero-subtitle { font-size: var(--text-xl); color: var(--color-text-secondary); max-width: 600px; margin: 0 auto var(--space-8); }
-.hero-stats { display: flex; gap: var(--space-8); justify-content: center; flex-wrap: wrap; margin-top: var(--space-8); }
-.hero-stat { text-align: center; }
-.hero-stat-num { font-family: var(--font-display); font-size: var(--text-3xl); font-weight: 800; color: var(--color-accent); display: block; }
-.hero-stat-label { font-size: var(--text-sm); color: var(--color-text-muted); }
-.hero-scroll-hint { margin-top: var(--space-12); font-size: var(--text-sm); color: var(--color-text-muted); animation: pulse 2s infinite; }
+.card-title {
+  font-family: 'Bricolage Grotesque', Georgia, serif;
+  font-weight: 700;
+  font-size: 1.15rem;
+  margin-bottom: 0.35rem;
+}
+.card-desc {
+  color: #6B6560;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  flex: 1;
+}
+.card-tag {
+  display: inline-block;
+  margin-top: 0.75rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+}
+.tag-live   { color: #2D8B55; background: #E8F5EE; }
+.tag-learn  { color: #2A7B9B; background: #E4F2F7; }
+.tag-data   { color: #7B6DAA; background: #F0ECF7; }
+.tag-docs   { color: #D4A843; background: #FDF5E4; }
+.tag-code   { color: #6B6560; background: #F0EDEA; }
+
+/* Full-width card for the first item */
+.card-featured {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 600px) {
+  .hero { padding: 3rem 1.5rem 1.5rem; }
+  .hero h1 { font-size: 2rem; }
+  .cards {
+    grid-template-columns: 1fr;
+    padding: 1rem 1.5rem 3rem;
+  }
+}
 </style>
 </head>
 <body>
 
-<!-- ============================================================
-     NAV
-     ============================================================ -->
-<nav class="nav" role="navigation" aria-label="Course navigation">
-  <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuenow="0"></div>
-  <div class="nav-inner">
-    <span class="nav-title">How Autoresearch Works</span>
-    <div class="nav-dots" role="tablist">
-      <button class="nav-dot" data-target="module-0" data-tooltip="Intro" role="tab" aria-label="Introduction"></button>
-      <button class="nav-dot" data-target="module-1" data-tooltip="First Run" role="tab" aria-label="Module 1"></button>
-      <button class="nav-dot" data-target="module-2" data-tooltip="Cast" role="tab" aria-label="Module 2"></button>
-      <button class="nav-dot" data-target="module-3" data-tooltip="Loop" role="tab" aria-label="Module 3"></button>
-      <button class="nav-dot" data-target="module-4" data-tooltip="Brain" role="tab" aria-label="Module 4"></button>
-      <button class="nav-dot" data-target="module-5" data-tooltip="Tricks" role="tab" aria-label="Module 5"></button>
-      <button class="nav-dot" data-target="module-6" data-tooltip="Resilience" role="tab" aria-label="Module 6"></button>
-      <button class="nav-dot" data-target="module-7" data-tooltip="Big Picture" role="tab" aria-label="Module 7"></button>
-    </div>
-  </div>
+<!-- Site Nav -->
+<nav class="site-nav" role="navigation" aria-label="Site navigation">
+  <a href="./" class="site-nav-brand">autoresearch</a>
+  <ul class="site-nav-links">
+    <li><a href="benchmark/">Benchmark</a></li>
+    <li><a href="course/">Course</a></li>
+    <li><a href="https://github.com/elementalcollision/autoresearch-unified" target="_blank">GitHub</a></li>
+  </ul>
 </nav>
 
-<!-- ============================================================
-     MODULE 0: HERO
-     ============================================================ -->
-<section class="module hero-module" id="module-0" style="background: var(--color-bg)">
-  <div class="module-content">
-    <header class="module-header animate-in">
-      <span class="hero-badge">Interactive Course</span>
-      <h1 class="hero-title">How Autoresearch Works</h1>
-      <p class="hero-subtitle">An AI scientist that runs thousands of GPU experiments autonomously &mdash; and the code that makes it tick. No CS degree required.</p>
-    </header>
-    <div class="hero-stats animate-in stagger-children">
-      <div class="hero-stat" style="--stagger-index:0"><span class="hero-stat-num">2,637+</span><span class="hero-stat-label">Experiments run</span></div>
-      <div class="hero-stat" style="--stagger-index:1"><span class="hero-stat-num">4</span><span class="hero-stat-label">GPU platforms</span></div>
-      <div class="hero-stat" style="--stagger-index:2"><span class="hero-stat-num">5 min</span><span class="hero-stat-label">Per experiment</span></div>
-      <div class="hero-stat" style="--stagger-index:3"><span class="hero-stat-num">1</span><span class="hero-stat-label">AI scientist (Claude)</span></div>
-    </div>
-    <p class="hero-scroll-hint animate-in">Scroll down to begin &darr;</p>
-  </div>
-</section>
+<div class="hero">
+  <h1>autoresearch-unified</h1>
+  <p>Autonomous LLM-driven hyperparameter optimization for GPU pretraining research. Claude designs experiments, trains GPT-2-scale models, and decides what to try next.</p>
+</div>
+
+<div class="cards">
+  <a href="benchmark/" class="card card-featured">
+    <div class="card-title">Benchmark Leaderboard</div>
+    <div class="card-desc">Ranking LLMs as autonomous ML researchers by keep rate, crash rate, and best validation bits-per-byte across GPUs and datasets.</div>
+    <span class="card-tag tag-live">Live Data</span>
+  </a>
+
+  <a href="course/" class="card">
+    <div class="card-title">Interactive Course</div>
+    <div class="card-desc">Learn how the entire system works — the experiment loop, crash resilience, and cross-platform training. No coding experience needed.</div>
+    <span class="card-tag tag-learn">7 Modules</span>
+  </a>
+
+  <a href="https://huggingface.co/datasets/davegraham/autoresearch-experiments" target="_blank" class="card">
+    <div class="card-title">Experiment Dataset</div>
+    <div class="card-desc">Full experimental data published on HuggingFace. Croissant-compliant, indexed on Google Dataset Search.</div>
+    <span class="card-tag tag-data">2,637+ Experiments</span>
+  </a>
+
+  <a href="https://github.com/elementalcollision/autoresearch-unified/wiki" target="_blank" class="card">
+    <div class="card-title">Documentation</div>
+    <div class="card-desc">Platform guides, dataset results, cross-platform analysis, and data access instructions.</div>
+    <span class="card-tag tag-docs">16 Pages</span>
+  </a>
+
+  <a href="https://github.com/elementalcollision/autoresearch-unified" target="_blank" class="card">
+    <div class="card-title">Source Code</div>
+    <div class="card-desc">Training scripts, experiment orchestration, and tooling for NVIDIA, AMD, Apple, and Intel platforms.</div>
+    <span class="card-tag tag-code">Open Source</span>
+  </a>
+</div>
+
+<footer class="site-footer">
+  <a href="https://github.com/elementalcollision/autoresearch-unified">GitHub</a>
+  <a href="https://huggingface.co/datasets/davegraham/autoresearch-experiments">HuggingFace</a>
+  <a href="https://github.com/elementalcollision/autoresearch-unified/wiki">Wiki</a>
+</footer>
 
-<!-- ============================================================
-     MODULE 1: WHAT HAPPENS WHEN YOU HIT "RUN"
-     ============================================================ -->
-<section class="module" id="module-1" style="background: var(--color-bg-warm)">
-  <div class="module-content">
-    <header class="module-header animate-in">
-      <span class="module-number">01</span>
-      <h1 class="module-title">What Happens When You Hit "Run"</h1>
-      <p class="module-subtitle">Trace the journey from a single command to a trained neural network</p>
-    </header>
-
-    <div class="module-body">
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The One-Line Magic Trick</h2>
-        <p>Imagine you&rsquo;re a researcher. You sit down at a computer connected to a powerful <span class="term" data-definition="A GPU (Graphics Processing Unit) is a specialized chip originally built for rendering video game graphics, but it turns out to be incredible at the math needed for AI training. Think of it as a factory with thousands of tiny workers that can all do simple math at the same time.">GPU</span>, type <code>python train.py</code>, and walk away. Five minutes later, you have a trained language model and a score that tells you how good it is.</p>
-        <p>But what actually happened in those five minutes? Let's trace every step.</p>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">Step 1: The Dispatcher</h2>
-        <p>The very first thing that runs is <code>train.py</code> &mdash; a tiny 40-line file whose only job is to figure out <em>what kind of GPU you have</em> and hand off to the right specialist.</p>
-        <p>Think of it like a hospital receptionist. You walk in and say "I need help." The receptionist doesn't treat you &mdash; they figure out which department to send you to.</p>
-
-        <div class="translation-block animate-in">
-          <div class="translation-code">
-            <span class="translation-label">CODE</span>
-            <pre><code><span class="code-keyword">from</span> backends <span class="code-keyword">import</span> <span class="code-function">detect_backend</span>
-<span class="code-keyword">from</span> backends.registry <span class="code-keyword">import</span> <span class="code-function">get_training_script</span>
-
-backend = <span class="code-function">detect_backend</span>()
-script_path = <span class="code-function">get_training_script</span>(backend)
-
-os.<span class="code-function">execv</span>(sys.executable, [sys.executable, script_path])</code></pre>
-          </div>
-          <div class="translation-english">
-            <span class="translation-label">PLAIN ENGLISH</span>
-            <div class="translation-lines">
-              <p class="tl">Bring in the "detective" tools that can identify GPU hardware</p>
-              <p class="tl">&nbsp;</p>
-              <p class="tl">Ask: "What GPU is installed on this machine?"</p>
-              <p class="tl">Look up: "For that GPU type, which training script should I run?"</p>
-              <p class="tl">&nbsp;</p>
-              <p class="tl">Replace myself entirely with the specialist script &mdash; I'm done, the specialist takes over from here</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="callout callout-accent animate-in">
-          <div class="callout-icon">&#x1f4a1;</div>
-          <div class="callout-content">
-            <strong class="callout-title">Key Insight: The Dispatcher Pattern</strong>
-            <p>This "detect and hand off" pattern is everywhere in software. Your phone does it when you tap a link &mdash; it figures out which app should open it (Safari? Chrome? YouTube?) and hands it off. When you tell an AI agent "build me a website," this pattern is how it figures out which tool to use for each step.</p>
-          </div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">Step 2: Detection Priority</h2>
-        <p>The detective checks hardware in a specific order, from most powerful to most common:</p>
-
-        <div class="step-cards stagger-children">
-          <div class="step-card animate-in" style="--stagger-index:0"><div class="step-num">1</div><div class="step-body"><strong>Intel Gaudi HPU</strong><p>Specialized AI chips &mdash; rarest, but purpose-built for training</p></div></div>
-          <div class="step-card animate-in" style="--stagger-index:1"><div class="step-num">2</div><div class="step-body"><strong>AMD ROCm (MI300X)</strong><p>AMD's datacenter GPUs &mdash; 192 GB of memory, massive compute</p></div></div>
-          <div class="step-card animate-in" style="--stagger-index:2"><div class="step-num">3</div><div class="step-body"><strong>NVIDIA CUDA</strong><p>The industry standard &mdash; from RTX 4090 to H100</p></div></div>
-          <div class="step-card animate-in" style="--stagger-index:3"><div class="step-num">4</div><div class="step-body"><strong>Apple MLX / MPS</strong><p>Your MacBook's built-in GPU &mdash; surprisingly capable</p></div></div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">Step 3: Five Minutes of Training</h2>
-        <p>Once the specialist script takes over, the same thing happens on every platform: build a small <span class="term" data-definition="A neural network is a program loosely inspired by the brain. It's made of layers of simple math operations that, when stacked together, can learn to predict text, recognize images, or generate code. Think of it as a very sophisticated pattern-matching machine.">neural network</span>, feed it text data for exactly 5 minutes, then measure how well it learned.</p>
-
-        <div class="flow-animation animate-in" id="flow-training">
-          <div class="flow-actors">
-            <div class="flow-actor" id="ft-data"><div class="flow-actor-icon" style="background: var(--color-actor-2)">D</div><span>Data Loader</span></div>
-            <div class="flow-actor" id="ft-model"><div class="flow-actor-icon" style="background: var(--color-actor-3)">M</div><span>Neural Network</span></div>
-            <div class="flow-actor" id="ft-optim"><div class="flow-actor-icon" style="background: var(--color-actor-4)">O</div><span>Optimizer</span></div>
-            <div class="flow-actor" id="ft-eval"><div class="flow-actor-icon" style="background: var(--color-actor-5)">E</div><span>Evaluator</span></div>
-          </div>
-          <div class="flow-step-label" id="ft-label">Click "Next Step" to see the training loop</div>
-          <div class="flow-controls">
-            <button onclick="ftNext()">Next Step</button>
-            <button onclick="ftReset()">Restart</button>
-            <span class="flow-progress" id="ft-progress">Step 0 / 6</span>
-          </div>
-        </div>
-      </section>
-
-      <!-- Quiz -->
-      <section class="screen animate-in" id="quiz-m1">
-        <h2 class="screen-heading">Check Your Understanding</h2>
-        <div class="quiz-container">
-          <div class="quiz-question-block" data-question="m1q1" data-correct="b">
-            <h3 class="quiz-question">You want to add support for a brand-new GPU from a startup called "NovAI." Where would you start?</h3>
-            <div class="quiz-options">
-              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Rewrite train.py to include NovAI-specific code</span></button>
-              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Add a new entry to the backends registry and create a new platform training script</span></button>
-              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Modify every existing training script to also check for NovAI hardware</span></button>
-            </div>
-            <div class="quiz-feedback" data-correct-text="The dispatcher pattern means train.py never needs to change. You'd add 'novai' to the registry, create platforms/novai/train_novai.py, and update detect_backend() &mdash; the rest of the system works automatically." data-incorrect-text="The whole point of the dispatcher is that train.py stays unchanged. You'd add the new backend to the registry and create a dedicated training script &mdash; no need to touch existing code."></div>
-          </div>
-          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m1')">Check Answer</button>
-        </div>
-      </section>
-    </div>
-  </div>
-</section>
-
-<!-- ============================================================
-     MODULE 2: MEET THE CAST
-     ============================================================ -->
-<section class="module" id="module-2" style="background: var(--color-bg)">
-  <div class="module-content">
-    <header class="module-header animate-in">
-      <span class="module-number">02</span>
-      <h1 class="module-title">Meet the Cast</h1>
-      <p class="module-subtitle">Every software project has characters. Here are the actors in this one.</p>
-    </header>
-
-    <div class="module-body">
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The Six Main Characters</h2>
-        <p>Think of this codebase like a film production. Each character has a specific role, and the movie falls apart if any one of them goes missing.</p>
-
-        <div class="icon-rows stagger-children">
-          <div class="icon-row animate-in" style="--stagger-index:0">
-            <div class="icon-circle" style="background: var(--color-actor-1)">O</div>
-            <div><strong>The Orchestrator</strong> <code>tui/orchestrator.py</code><p>The director. Runs the experiment loop, tells everyone what to do, keeps track of results.</p></div>
-          </div>
-          <div class="icon-row animate-in" style="--stagger-index:1">
-            <div class="icon-circle" style="background: var(--color-actor-2)">C</div>
-            <div><strong>Claude (LLM Backend)</strong> <code>tui/llm_backend.py</code><p>The scientist. Analyzes past experiments and proposes what to try next.</p></div>
-          </div>
-          <div class="icon-row animate-in" style="--stagger-index:2">
-            <div class="icon-circle" style="background: var(--color-actor-3)">T</div>
-            <div><strong>The Trainer</strong> <code>platforms/*/train_*.py</code><p>The lab technician. Actually runs the GPU and trains the neural network.</p></div>
-          </div>
-          <div class="icon-row animate-in" style="--stagger-index:3">
-            <div class="icon-circle" style="background: var(--color-actor-4)">G</div>
-            <div><strong>Git Manager</strong> <code>tui/git_manager.py</code><p>The librarian. Saves every experiment as a permanent record you can revisit.</p></div>
-          </div>
-          <div class="icon-row animate-in" style="--stagger-index:4">
-            <div class="icon-circle" style="background: var(--color-actor-5)">R</div>
-            <div><strong>Results Logger</strong> <code>tui/results.py</code><p>The scorekeeper. Writes results to a spreadsheet that never loses data, even if the power goes out.</p></div>
-          </div>
-          <div class="icon-row animate-in" style="--stagger-index:5">
-            <div class="icon-circle" style="background: #888">P</div>
-            <div><strong>Data Preparer</strong> <code>prepare.py</code><p>The prep cook. Downloads training data and builds the vocabulary before anyone else starts working.</p></div>
-          </div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The Project Layout</h2>
-        <p>Here's how these characters are organized in the actual code:</p>
-
-        <div class="file-tree animate-in">
-          <div class="ft-folder open">
-            <span class="ft-name">autoresearch-unified/</span>
-            <div class="ft-children">
-              <div class="ft-file"><span class="ft-name">train.py</span> <span class="ft-desc">The receptionist (40 lines)</span></div>
-              <div class="ft-file"><span class="ft-name">prepare.py</span> <span class="ft-desc">Downloads data + trains tokenizer</span></div>
-              <div class="ft-file"><span class="ft-name">run_suite.py</span> <span class="ft-desc">Runs experiments across many datasets overnight</span></div>
-              <div class="ft-folder open">
-                <span class="ft-name">tui/</span> <span class="ft-desc">The brain &mdash; orchestration, UI, Claude API</span>
-                <div class="ft-children">
-                  <div class="ft-file"><span class="ft-name">orchestrator.py</span> <span class="ft-desc">The director (880 lines)</span></div>
-                  <div class="ft-file"><span class="ft-name">llm_backend.py</span> <span class="ft-desc">Talks to Claude</span></div>
-                  <div class="ft-file"><span class="ft-name">results.py</span> <span class="ft-desc">Crash-safe scorekeeper</span></div>
-                  <div class="ft-file"><span class="ft-name">resilience.py</span> <span class="ft-desc">Crash protection</span></div>
-                </div>
-              </div>
-              <div class="ft-folder open">
-                <span class="ft-name">backends/</span> <span class="ft-desc">GPU detection + optimizers</span>
-                <div class="ft-children">
-                  <div class="ft-file"><span class="ft-name">__init__.py</span> <span class="ft-desc">Hardware detective</span></div>
-                  <div class="ft-file"><span class="ft-name">muon_cuda.py</span> <span class="ft-desc">NVIDIA optimizer</span></div>
-                  <div class="ft-file"><span class="ft-name">muon_rocm.py</span> <span class="ft-desc">AMD optimizer</span></div>
-                  <div class="ft-file"><span class="ft-name">muon_mlx.py</span> <span class="ft-desc">Apple optimizer</span></div>
-                </div>
-              </div>
-              <div class="ft-folder open">
-                <span class="ft-name">platforms/</span> <span class="ft-desc">One training script per GPU type</span>
-                <div class="ft-children">
-                  <div class="ft-folder"><span class="ft-name">cuda/</span> <span class="ft-desc">NVIDIA GPUs</span></div>
-                  <div class="ft-folder"><span class="ft-name">rocm/</span> <span class="ft-desc">AMD GPUs</span></div>
-                  <div class="ft-folder"><span class="ft-name">metal/</span> <span class="ft-desc">Apple Silicon</span></div>
-                  <div class="ft-folder"><span class="ft-name">gaudi/</span> <span class="ft-desc">Intel Gaudi</span></div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">How They Talk to Each Other</h2>
-        <p>Watch how the Orchestrator coordinates a single experiment:</p>
-
-        <div class="chat-window" id="chat-cast">
-          <div class="chat-header">Experiment #42 &mdash; Component Chat</div>
-          <div class="chat-messages" id="chat-cast-msgs">
-            <div class="chat-message" data-sender="orch" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-1)">O</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">Orchestrator</span><p>Hey Claude, here are the results from our last 41 experiments. What should we try next?</p></div></div>
-            <div class="chat-message" data-sender="claude" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-2)">C</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-2)">Claude</span><p>Looking at the trend... the learning rate sweet spot seems to be around 0.003. Let's try increasing the model depth from 8 to 10 layers.</p></div></div>
-            <div class="chat-message" data-sender="orch" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-1)">O</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">Orchestrator</span><p>Got it. Git Manager, save the current code and commit this change.</p></div></div>
-            <div class="chat-message" data-sender="git" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-4)">G</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-4)">Git Manager</span><p>Done! Committed as "exp42: increase depth from 8 to 10 layers" &mdash; SHA: a1b2c3d</p></div></div>
-            <div class="chat-message" data-sender="orch" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-1)">O</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">Orchestrator</span><p>Trainer, run this for 5 minutes on the GPU.</p></div></div>
-            <div class="chat-message" data-sender="trainer" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-3)">T</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-3)">Trainer</span><p>Training complete! val_bpb: 1.234, that's better than our previous best of 1.289!</p></div></div>
-            <div class="chat-message" data-sender="orch" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-1)">O</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">Orchestrator</span><p>New record! Results Logger, mark this as KEEP.</p></div></div>
-            <div class="chat-message" data-sender="results" style="display:none"><div class="chat-avatar" style="background: var(--color-actor-5)">R</div><div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-5)">Results Logger</span><p>Saved to results.tsv with atomic write. Even if the power dies right now, this result is safe.</p></div></div>
-          </div>
-          <div class="chat-typing" id="chat-cast-typing" style="display:none">
-            <div class="chat-avatar" id="cast-typing-avatar" style="background: var(--color-text-muted)">?</div>
-            <div class="chat-typing-dots"><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div>
-          </div>
-          <div class="chat-controls">
-            <button onclick="playChatNext('cast')">Next Message</button>
-            <button onclick="playChatAll('cast')">Play All</button>
-            <button onclick="resetChat('cast')">Replay</button>
-            <span class="chat-progress" id="chat-cast-progress">0 / 8 messages</span>
-          </div>
-        </div>
-      </section>
-
-      <!-- Quiz -->
-      <section class="screen animate-in" id="quiz-m2">
-        <h2 class="screen-heading">Check Your Understanding</h2>
-        <div class="quiz-container">
-          <div class="quiz-question-block" data-question="m2q1" data-correct="b">
-            <h3 class="quiz-question">The training just finished, but the results show a worse score than before. Which component decides whether to keep or discard the experiment?</h3>
-            <div class="quiz-options">
-              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Claude (the LLM Backend)</span></button>
-              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The Orchestrator</span></button>
-              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The Trainer</span></button>
-            </div>
-            <div class="quiz-feedback" data-correct-text="The Orchestrator compares the new val_bpb against the best so far and decides keep/discard. Claude proposes experiments but doesn't judge results &mdash; the Orchestrator is the decision-maker." data-incorrect-text="Claude proposes experiments and the Trainer runs them, but the Orchestrator is the one who compares scores and marks experiments as 'keep' or 'discard.'"></div>
-          </div>
-          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m2')">Check Answer</button>
-        </div>
-      </section>
-    </div>
-  </div>
-</section>
-
-<!-- ============================================================
-     MODULE 3: THE EXPERIMENT LOOP
-     ============================================================ -->
-<section class="module" id="module-3" style="background: var(--color-bg-warm)">
-  <div class="module-content">
-    <header class="module-header animate-in">
-      <span class="module-number">03</span>
-      <h1 class="module-title">The Experiment Loop</h1>
-      <p class="module-subtitle">The engine that runs thousands of experiments while you sleep</p>
-    </header>
-
-    <div class="module-body">
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The Scientific Method, Automated</h2>
-        <p>Traditional research: a human reads papers, forms a hypothesis, runs an experiment, analyzes results, and repeats. This system does the same thing, but the "human" is <span class="term" data-definition="Claude is an AI assistant made by Anthropic. In this system, it acts as the 'scientist' &mdash; reading past experimental results and proposing what to try next, like a researcher who never sleeps and has perfect memory of every past experiment.">Claude</span>, and it never needs sleep.</p>
-        <p>Each cycle takes about 6 minutes: 1 minute for Claude to think + 5 minutes of training. That means roughly 80 experiments per 8-hour overnight run.</p>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">What Claude Actually Sees</h2>
-        <p>Before each experiment, the Orchestrator sends Claude a carefully crafted message containing the experiment history and the editable code. Claude's job: change ONE thing in the <span class="term" data-definition="Hyperparameters are the 'knobs and dials' of a neural network &mdash; settings like learning rate, model size, and batch size that you choose before training. They're 'hyper' because they control the regular parameters that the model learns on its own.">hyperparameter</span> block.</p>
-
-        <div class="translation-block animate-in">
-          <div class="translation-code">
-            <span class="translation-label">WHAT CLAUDE SEES</span>
-            <pre><code><span class="code-comment"># Hyperparameters</span>
-DEPTH = <span class="code-number">8</span>
-DEVICE_BATCH_SIZE = <span class="code-number">64</span>
-TOTAL_BATCH_SIZE = <span class="code-number">2</span> ** <span class="code-number">17</span>
-LEARNING_RATE = <span class="code-number">0.003</span>
-WEIGHT_DECAY = <span class="code-number">0.05</span>
-WARMUP_ITERS = <span class="code-number">0</span>
-COOLDOWN_FRAC = <span class="code-number">0.4</span></code></pre>
-          </div>
-          <div class="translation-english">
-            <span class="translation-label">PLAIN ENGLISH</span>
-            <div class="translation-lines">
-              <p class="tl">These are the settings Claude can adjust:</p>
-              <p class="tl"><strong>DEPTH = 8</strong> &mdash; How many layers deep the brain is (more = smarter, but slower)</p>
-              <p class="tl"><strong>DEVICE_BATCH_SIZE = 64</strong> &mdash; How many text samples to process at once</p>
-              <p class="tl"><strong>TOTAL_BATCH_SIZE</strong> &mdash; Total samples before updating the brain</p>
-              <p class="tl"><strong>LEARNING_RATE</strong> &mdash; How aggressively to learn (too high = unstable, too low = slow)</p>
-              <p class="tl"><strong>WEIGHT_DECAY</strong> &mdash; Slight "forgetfulness" that prevents over-memorizing</p>
-              <p class="tl"><strong>WARMUP_ITERS</strong> &mdash; Steps of gentle start before full speed</p>
-              <p class="tl"><strong>COOLDOWN_FRAC</strong> &mdash; Portion of time spent gradually slowing down</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The Results Spreadsheet</h2>
-        <p>Every experiment produces one row in a <span class="term" data-definition="TSV stands for Tab-Separated Values &mdash; a simple spreadsheet format where each column is separated by a tab character. Think of it as a super-simple Excel file that any program can read.">TSV</span> file. This is the project's source of truth &mdash; the complete history of every experiment ever run.</p>
-
-        <div class="badge-list animate-in">
-          <div class="badge-item"><code class="badge-code">exp</code><span>Experiment number (exp0, exp1, exp2...)</span></div>
-          <div class="badge-item"><code class="badge-code">description</code><span>What Claude changed ("increase depth to 10")</span></div>
-          <div class="badge-item"><code class="badge-code">val_bpb</code><span>The score &mdash; lower is better (bits per byte)</span></div>
-          <div class="badge-item"><code class="badge-code">mfu</code><span>How efficiently the GPU was used (%)</span></div>
-          <div class="badge-item"><code class="badge-code">status</code><span>keep, discard, baseline, or crash</span></div>
-          <div class="badge-item"><code class="badge-code">baseline_sha</code><span>Git fingerprint linking to exact code version</span></div>
-        </div>
-
-        <div class="callout callout-info animate-in">
-          <div class="callout-icon">&#x1f50d;</div>
-          <div class="callout-content">
-            <strong class="callout-title">Why "Bits Per Byte"?</strong>
-            <p>Different <span class="term" data-definition="A tokenizer breaks text into chunks called tokens. 'Hello world' might become ['Hello', ' world'] &mdash; two tokens. Different tokenizers break text differently, like how different languages carve up words differently.">tokenizers</span> split text into different-sized pieces, making raw loss numbers incomparable. Bits-per-byte converts to a universal scale: "how many bits of information do you need to predict each byte of text?" Lower means the model learned better patterns.</p>
-          </div>
-        </div>
-      </section>
-
-      <!-- Quiz -->
-      <section class="screen animate-in" id="quiz-m3">
-        <h2 class="screen-heading">Check Your Understanding</h2>
-        <div class="quiz-container">
-          <div class="quiz-question-block" data-question="m3q1" data-correct="c">
-            <h3 class="quiz-question">Claude proposes changing BOTH the learning rate and the model depth at the same time. Why would the system's rules prevent this?</h3>
-            <div class="quiz-options">
-              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Changing two things uses too much GPU memory</span></button>
-              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The code can only handle one change per commit</span></button>
-              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>If the result improves, you won't know which change caused it</span></button>
-            </div>
-            <div class="quiz-feedback" data-correct-text="Exactly! This is the scientific principle of 'controlled experiments' &mdash; change one variable at a time so you can attribute cause and effect. If you change two things and the score improves, you learn nothing about which one helped." data-incorrect-text="The real reason is scientific rigor: if you change two things and the result improves, you can't tell which change helped. The system enforces ONE change per experiment so every result is interpretable."></div>
-          </div>
-          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m3')">Check Answer</button>
-        </div>
-      </section>
-    </div>
-  </div>
-</section>
-
-<!-- ============================================================
-     MODULE 4: INSIDE THE NEURAL NETWORK
-     ============================================================ -->
-<section class="module" id="module-4" style="background: var(--color-bg)">
-  <div class="module-content">
-    <header class="module-header animate-in">
-      <span class="module-number">04</span>
-      <h1 class="module-title">Inside the Neural Network</h1>
-      <p class="module-subtitle">What's actually inside the brain this system trains?</p>
-    </header>
-
-    <div class="module-body">
-      <section class="screen animate-in">
-        <h2 class="screen-heading">A Transformer, in Plain English</h2>
-        <p>The model is a <span class="term" data-definition="A Transformer is the architecture behind GPT, Claude, and most modern AI. It's called a 'transformer' because it transforms input text into output predictions using a mechanism called 'attention' that lets it focus on relevant words, regardless of how far apart they are.">Transformer</span> &mdash; the same family as GPT and Claude, but miniature. Where GPT-4 has hundreds of billions of <span class="term" data-definition="Parameters are the numbers the model learns during training. They're like the knobs on a mixing board &mdash; millions of tiny adjustments that together determine how the model responds to any input. More parameters generally means a more capable model.">parameters</span>, this one has 1&ndash;10 million. It's small enough to train in 5 minutes, but big enough to actually learn language patterns.</p>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The Building Blocks</h2>
-        <p>Every Transformer is built from the same LEGO bricks, stacked on top of each other. Imagine a conveyor belt in a factory: raw text goes in one end, predictions come out the other, passing through specialized stations.</p>
-
-        <div class="pattern-cards stagger-children">
-          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2); --stagger-index:0">
-            <div class="pattern-icon" style="background: var(--color-actor-2)">Aa</div>
-            <h4 class="pattern-title">Embedding</h4>
-            <p class="pattern-desc">Converts each word-piece into a list of numbers (a "vector") that the math can work with. Like translating English into the language of mathematics.</p>
-          </div>
-          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-3); --stagger-index:1">
-            <div class="pattern-icon" style="background: var(--color-actor-3)">&#x1f441;</div>
-            <h4 class="pattern-title">Attention</h4>
-            <p class="pattern-desc">Each word "looks at" every other word to understand context. "Bank" means something different near "river" vs. "money." This layer figures that out.</p>
-          </div>
-          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4); --stagger-index:2">
-            <div class="pattern-icon" style="background: var(--color-actor-4)">&#x26a1;</div>
-            <h4 class="pattern-title">MLP (ReLU²)</h4>
-            <p class="pattern-desc">A "thinking" layer that processes what attention found. It expands the information, applies a non-linear filter, then compresses it back down.</p>
-          </div>
-          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5); --stagger-index:3">
-            <div class="pattern-icon" style="background: var(--color-actor-5)">&#x1f3af;</div>
-            <h4 class="pattern-title">Output Head</h4>
-            <p class="pattern-desc">Converts the final numbers back into a probability for every possible next word. The highest probability wins.</p>
-          </div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The Clever Tricks</h2>
-        <p>This isn't a textbook Transformer. It uses several cutting-edge techniques that improve performance on small models:</p>
-
-        <div class="step-cards stagger-children">
-          <div class="step-card animate-in" style="--stagger-index:0; border-left-color: var(--color-actor-3)"><div class="step-num" style="background: var(--color-actor-3)">1</div><div class="step-body"><strong>Sliding Window Attention</strong><p>Not every layer needs to look at the full text. Alternate layers use a "short window" &mdash; like reading with a magnifying glass vs. scanning the whole page. Saves compute, barely hurts quality.</p></div></div>
-          <div class="step-card animate-in" style="--stagger-index:1; border-left-color: var(--color-actor-4)"><div class="step-num" style="background: var(--color-actor-4)">2</div><div class="step-body"><strong>Value Residual (ResFormer)</strong><p>Some layers get an extra "cheat sheet" that feeds raw vocabulary information directly into the attention. Like an open-book exam instead of pure memory.</p></div></div>
-          <div class="step-card animate-in" style="--stagger-index:2; border-left-color: var(--color-actor-5)"><div class="step-num" style="background: var(--color-actor-5)">3</div><div class="step-body"><strong>Learnable Residual Scaling</strong><p>Each layer gets its own volume dial. The model learns how much to "listen" to each layer's contribution vs. the original signal.</p></div></div>
-          <div class="step-card animate-in" style="--stagger-index:3; border-left-color: var(--color-actor-1)"><div class="step-num" style="background: var(--color-actor-1)">4</div><div class="step-body"><strong>Logit Softcap</strong><p>Prevents the model from becoming "too confident." A mathematical ceiling that squashes extreme predictions, keeping the model honest.</p></div></div>
-        </div>
-      </section>
-
-      <!-- Quiz -->
-      <section class="screen animate-in" id="quiz-m4">
-        <h2 class="screen-heading">Check Your Understanding</h2>
-        <div class="quiz-container">
-          <div class="quiz-question-block" data-question="m4q1" data-correct="a">
-            <h3 class="quiz-question">You're building a chatbot and the AI keeps giving wildly overconfident answers. Which technique from this module could help?</h3>
-            <div class="quiz-options">
-              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Logit softcap &mdash; it squashes extreme predictions</span></button>
-              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Sliding window attention &mdash; it limits context</span></button>
-              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Value residual &mdash; it adds raw vocabulary information</span></button>
-            </div>
-            <div class="quiz-feedback" data-correct-text="Logit softcap applies tanh(logits / cap) * cap, mathematically preventing any prediction from becoming unreasonably extreme. It's like a speed limiter on confidence." data-incorrect-text="The logit softcap is specifically designed for this &mdash; it applies a mathematical ceiling that prevents any single prediction from becoming too extreme. Sliding window is about memory efficiency, and value residual adds information rather than limiting it."></div>
-          </div>
-          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m4')">Check Answer</button>
-        </div>
-      </section>
-    </div>
-  </div>
-</section>
-
-<!-- ============================================================
-     MODULE 5: THE OPTIMIZER (SECRET SAUCE)
-     ============================================================ -->
-<section class="module" id="module-5" style="background: var(--color-bg-warm)">
-  <div class="module-content">
-    <header class="module-header animate-in">
-      <span class="module-number">05</span>
-      <h1 class="module-title">The Secret Sauce: MuonAdamW</h1>
-      <p class="module-subtitle">The custom optimizer that's half math genius, half Swiss Army knife</p>
-    </header>
-
-    <div class="module-body">
-      <section class="screen animate-in">
-        <h2 class="screen-heading">What Is an Optimizer?</h2>
-        <p>Training a neural network is like navigating a mountainous landscape blindfolded. You can feel the slope under your feet (the <span class="term" data-definition="A gradient tells you which direction is 'downhill' for each parameter. If you're training a model, gradients are the compass &mdash; they point toward settings that would reduce errors. The optimizer uses gradients to decide which direction to adjust the model's millions of parameters.">gradient</span>), but you need a strategy for which direction to step and how far. That strategy is the <span class="term" data-definition="An optimizer is the algorithm that decides how to update a neural network's parameters after each training step. It's the 'navigator' that uses gradient information to decide: 'move this parameter up a little, that one down a lot.' Different optimizers use different navigation strategies.">optimizer</span>.</p>
-        <p>Most AI systems use one optimizer for everything. Autoresearch uses a <em>hybrid</em> &mdash; two different strategies combined into one, each applied to the type of parameter it works best on.</p>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">Two Optimizers, One System</h2>
-
-        <div class="pattern-cards animate-in">
-          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
-            <div class="pattern-icon" style="background: var(--color-actor-2)">M</div>
-            <h4 class="pattern-title">Muon</h4>
-            <p class="pattern-desc">For the big matrix parameters (attention, MLP weights). Uses a fancy math trick called "orthogonalization" &mdash; imagine straightening all the learning directions so they don't interfere with each other.</p>
-          </div>
-          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
-            <div class="pattern-icon" style="background: var(--color-actor-4)">A</div>
-            <h4 class="pattern-title">AdamW</h4>
-            <p class="pattern-desc">For everything else (embeddings, scaling factors, biases). The industry workhorse &mdash; tracks both momentum and variance of gradients to make smooth, stable updates.</p>
-          </div>
-        </div>
-
-        <div class="callout callout-accent animate-in">
-          <div class="callout-icon">&#x1f4a1;</div>
-          <div class="callout-content">
-            <strong class="callout-title">Why Two Optimizers?</strong>
-            <p>Different parameter shapes have different geometry. A 768&times;768 weight matrix lives in a very different mathematical space than a single scaling number. Using the right tool for each shape is like using a screwdriver for screws and a wrench for bolts, instead of hammering everything.</p>
-          </div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The Learning Rate Menu</h2>
-        <p>Not all parameters learn at the same speed. The optimizer assigns different learning rates to different groups, like different speed limits for different road types:</p>
-
-        <div class="badge-list animate-in">
-          <div class="badge-item"><code class="badge-code">0.04</code><span>Transformer matrices (Muon) &mdash; fast learners</span></div>
-          <div class="badge-item"><code class="badge-code">0.6</code><span>Token embeddings (AdamW) &mdash; vocabulary needs lots of tuning</span></div>
-          <div class="badge-item"><code class="badge-code">0.004</code><span>Output head (AdamW) &mdash; initialized near zero, learns gently</span></div>
-          <div class="badge-item"><code class="badge-code">0.5</code><span>Skip-connection weights (AdamW) &mdash; quick-adjusting dials</span></div>
-          <div class="badge-item"><code class="badge-code">0.005</code><span>Residual scales (AdamW) &mdash; per-layer volume, nearly fixed</span></div>
-        </div>
-      </section>
-
-      <!-- Quiz -->
-      <section class="screen animate-in" id="quiz-m5">
-        <h2 class="screen-heading">Check Your Understanding</h2>
-        <div class="quiz-container">
-          <div class="quiz-question-block" data-question="m5q1" data-correct="b">
-            <h3 class="quiz-question">You're debugging a training run where the model starts learning well but then "forgets" everything after step 200. Which optimizer feature is most likely relevant?</h3>
-            <div class="quiz-options">
-              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The Muon orthogonalization step</span></button>
-              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The learning rate warmup/cooldown schedule</span></button>
-              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The cautious weight decay mechanism</span></button>
-            </div>
-            <div class="quiz-feedback" data-correct-text="A model that learns then suddenly destabilizes usually has a learning rate problem. The warmup/cooldown schedule ramps the rate up gradually and then reduces it toward the end. If the warmup is wrong, the model can overshoot its sweet spot and diverge." data-incorrect-text="When a model learns well then suddenly 'forgets,' the most common culprit is the learning rate schedule. Too aggressive after warmup and the optimizer overshoots, destroying what it learned."></div>
-          </div>
-          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m5')">Check Answer</button>
-        </div>
-      </section>
-    </div>
-  </div>
-</section>
-
-<!-- ============================================================
-     MODULE 6: WHEN THINGS BREAK
-     ============================================================ -->
-<section class="module" id="module-6" style="background: var(--color-bg)">
-  <div class="module-content">
-    <header class="module-header animate-in">
-      <span class="module-number">06</span>
-      <h1 class="module-title">When Things Break</h1>
-      <p class="module-subtitle">How the system survives crashes, power outages, and GPU meltdowns</p>
-    </header>
-
-    <div class="module-body">
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The Problem: 3 AM Crashes</h2>
-        <p>Imagine you start an 80-experiment run before bed. At experiment #47, the cloud provider reboots the machine, or the GPU runs out of memory, or the internet drops. Without protection, you'd lose everything and have to restart from scratch.</p>
-        <p>This system is built like a black box flight recorder &mdash; it survives almost anything.</p>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">Defense #1: Atomic Writes</h2>
-        <p>The biggest risk is a half-written results file. If the power dies mid-write, the file could be corrupted. The fix: <span class="term" data-definition="An atomic write is a technique where you write data to a temporary file first, then instantly swap it with the real file using a special operating system command. It's like writing a letter on a fresh sheet, then swapping it onto the stack in one motion &mdash; the stack is never in a half-updated state.">atomic writes</span>.</p>
-
-        <div class="step-cards animate-in">
-          <div class="step-card"><div class="step-num">1</div><div class="step-body"><strong>Write to a temporary file</strong><p>results.tsv.tmp gets the new data</p></div></div>
-          <div class="step-card"><div class="step-num">2</div><div class="step-body"><strong>Force-flush to disk</strong><p><code>fsync()</code> ensures the data is physically written, not just cached</p></div></div>
-          <div class="step-card"><div class="step-num">3</div><div class="step-body"><strong>Atomic rename</strong><p><code>os.replace()</code> swaps the temp file for the real one in a single, uninterruptible operation</p></div></div>
-        </div>
-
-        <div class="callout callout-accent animate-in">
-          <div class="callout-icon">&#x1f4a1;</div>
-          <div class="callout-content">
-            <strong class="callout-title">Atomic Operations Are Everywhere</strong>
-            <p>Every database, every banking system, every app that can't afford to lose data uses this same principle. The operating system guarantees that <code>rename()</code> either fully completes or doesn't happen at all &mdash; there's no in-between. When you tell AI to "save data safely," this is the technique you want it to use.</p>
-          </div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">Defense #2: Heartbeat Monitoring</h2>
-        <p>How do you know if an overnight run is still alive? The system writes a "heartbeat" file every iteration &mdash; like a hospital monitor beeping to show the patient is still breathing.</p>
-
-        <div class="translation-block animate-in">
-          <div class="translation-code">
-            <span class="translation-label">CODE</span>
-            <pre><code><span class="code-keyword">class</span> <span class="code-function">Heartbeat</span>:
-    <span class="code-keyword">def</span> <span class="code-function">update</span>(self, status, experiment, message):
-        data = {
-            <span class="code-string">"status"</span>: status,
-            <span class="code-string">"experiment"</span>: experiment,
-            <span class="code-string">"timestamp"</span>: time.time(),
-            <span class="code-string">"pid"</span>: os.getpid(),
-        }
-        <span class="code-function">atomic_write</span>(self.path, json.dumps(data))</code></pre>
-          </div>
-          <div class="translation-english">
-            <span class="translation-label">PLAIN ENGLISH</span>
-            <div class="translation-lines">
-              <p class="tl">Create a "heartbeat monitor" object</p>
-              <p class="tl">Every time we finish something, record a pulse:</p>
-              <p class="tl">What are we doing? ("training", "evaluating")</p>
-              <p class="tl">Which experiment number?</p>
-              <p class="tl">Exactly when? (for "how long since last beat?")</p>
-              <p class="tl">Which process is running? (to detect zombies)</p>
-              <p class="tl">Save this pulse using the atomic write technique from before</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">Defense #3: Resume from Crash</h2>
-        <p>When the system restarts after a crash, it doesn't start over. It reads the existing results file, finds the last completed experiment, cleans up any half-finished work (like orphaned <span class="term" data-definition="A git commit is a snapshot of your code at a specific moment in time. Like a save point in a video game &mdash; you can always go back to any commit and see exactly what the code looked like at that moment.">git commits</span>), and picks up where it left off.</p>
-      </section>
-
-      <!-- Quiz -->
-      <section class="screen animate-in" id="quiz-m6">
-        <h2 class="screen-heading">Check Your Understanding</h2>
-        <div class="quiz-container">
-          <div class="quiz-question-block" data-question="m6q1" data-correct="a">
-            <h3 class="quiz-question">Your overnight run crashed at experiment #50. When you restart, the system finds a git commit for "exp50" but no matching row in results.tsv. What should it do?</h3>
-            <div class="quiz-options">
-              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Revert the orphaned commit and re-run experiment #50</span></button>
-              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Keep the commit and skip to experiment #51</span></button>
-              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>Delete results.tsv and start from scratch</span></button>
-            </div>
-            <div class="quiz-feedback" data-correct-text="A commit without a result means the experiment crashed before completing. The system reverts the orphaned commit (cleaning up the mess) and starts fresh from the same experiment number. This is the cleanup logic in _cleanup_interrupted_experiment()." data-incorrect-text="Skipping would leave a gap in the results, and deleting the file would lose all 49 good experiments. The correct approach is to revert the orphaned commit (it represents incomplete work) and re-run experiment #50."></div>
-          </div>
-          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m6')">Check Answer</button>
-        </div>
-      </section>
-    </div>
-  </div>
-</section>
-
-<!-- ============================================================
-     MODULE 7: THE BIG PICTURE
-     ============================================================ -->
-<section class="module" id="module-7" style="background: var(--color-bg-warm)">
-  <div class="module-content">
-    <header class="module-header animate-in">
-      <span class="module-number">07</span>
-      <h1 class="module-title">The Big Picture</h1>
-      <p class="module-subtitle">Zoom out: how four GPU platforms become one unified research machine</p>
-    </header>
-
-    <div class="module-body">
-      <section class="screen animate-in">
-        <h2 class="screen-heading">One Brain, Four Bodies</h2>
-        <p>The real engineering achievement here isn't any single component &mdash; it's that the same experiment can run on an Apple MacBook, an NVIDIA data center GPU, an AMD MI300X, or an Intel Gaudi chip, and the results are directly comparable.</p>
-        <p>Think of it like a recipe that works in any kitchen: gas stove, electric, induction, or campfire. The dish tastes the same because the recipe (the algorithm) is the same &mdash; only the cooking equipment (the GPU) changes.</p>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">The Architecture, at a Glance</h2>
-        <div class="arch-diagram animate-in" id="arch-main">
-          <div class="arch-zones">
-            <div class="arch-zone">
-              <h4 class="arch-zone-label">Shared Layer (Platform-Agnostic)</h4>
-              <div class="arch-component" data-desc="The brain: proposes experiments, manages the loop, records results. Same code runs everywhere." onclick="showArchDesc(this)"><div class="arch-icon">&#x1f3ac;</div><span>Orchestrator + TUI</span></div>
-              <div class="arch-component" data-desc="Downloads ClimbMix data, trains the BPE tokenizer, provides data loaders. Identical across platforms." onclick="showArchDesc(this)"><div class="arch-icon">&#x1f4e6;</div><span>Data Pipeline (prepare.py)</span></div>
-              <div class="arch-component" data-desc="Analyzes experiments and proposes changes. Same API calls regardless of GPU type." onclick="showArchDesc(this)"><div class="arch-icon">&#x1f916;</div><span>Claude API (llm_backend.py)</span></div>
-              <div class="arch-component" data-desc="Crash-safe results, atomic writes, heartbeat, signal handlers. Shared across all platforms." onclick="showArchDesc(this)"><div class="arch-icon">&#x1f6e1;</div><span>Resilience Layer</span></div>
-            </div>
-            <div class="arch-zone">
-              <h4 class="arch-zone-label">Platform Layer (GPU-Specific)</h4>
-              <div class="arch-component" data-desc="NVIDIA: torch.compile + FlashAttention-2 + CUDA graphs. The fastest platform with 33.7% MFU on RTX PRO 6000." onclick="showArchDesc(this)"><div class="arch-icon" style="color: var(--color-actor-5)">&#x1f7e2;</div><span>CUDA Training</span></div>
-              <div class="arch-component" data-desc="AMD MI300X: CK attention kernels + Triton fusion. 192 GB VRAM but 7.1% MFU (torch.compile disabled due to Inductor crash)." onclick="showArchDesc(this)"><div class="arch-icon" style="color: var(--color-actor-1)">&#x1f534;</div><span>ROCm Training</span></div>
-              <div class="arch-component" data-desc="Apple Silicon: Native MLX framework (not PyTorch). Runs on MacBook Pro. Lower throughput but zero cloud cost." onclick="showArchDesc(this)"><div class="arch-icon" style="color: var(--color-actor-2)">&#x1f535;</div><span>MLX Training</span></div>
-              <div class="arch-component" data-desc="Intel Gaudi 3: Specialized AI chip with 128 GB HBM. Uses Habana's FusedSDPA for attention." onclick="showArchDesc(this)"><div class="arch-icon" style="color: var(--color-actor-3)">&#x1f7e3;</div><span>Gaudi HPU Training</span></div>
-            </div>
-          </div>
-          <div class="arch-description" id="arch-main-desc">Click any component to learn what it does</div>
-        </div>
-      </section>
-
-      <section class="screen animate-in">
-        <h2 class="screen-heading">What You Can Do Now</h2>
-        <p>You've just learned how a real, production AI research system works from the inside. Here's what this knowledge unlocks:</p>
-
-        <div class="pattern-cards stagger-children">
-          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1); --stagger-index:0">
-            <h4 class="pattern-title">Steer AI Agents Better</h4>
-            <p class="pattern-desc">You can now say "use a dispatcher pattern" instead of "make it work on different computers." Precise vocabulary = precise results.</p>
-          </div>
-          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2); --stagger-index:1">
-            <h4 class="pattern-title">Debug Smarter</h4>
-            <p class="pattern-desc">When something breaks, you know to check: Is it the data? The model? The optimizer? The platform layer? You can narrow down problems systematically.</p>
-          </div>
-          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5); --stagger-index:2">
-            <h4 class="pattern-title">Make Architecture Decisions</h4>
-            <p class="pattern-desc">Dispatcher pattern vs. monolith. Atomic writes vs. hope-for-the-best. Hybrid optimizers vs. one-size-fits-all. You have the vocabulary to choose wisely.</p>
-          </div>
-        </div>
-      </section>
-
-      <!-- Final Quiz -->
-      <section class="screen animate-in" id="quiz-m7">
-        <h2 class="screen-heading">Final Challenge</h2>
-        <div class="quiz-container">
-          <div class="quiz-question-block" data-question="m7q1" data-correct="c">
-            <div class="scenario-block">
-              <span class="scenario-label">Scenario</span>
-              <p>You're setting up autoresearch on a new AMD MI300X machine and the training runs are 4.7x slower than the same experiments on NVIDIA. You check the logs and see "torch.compile disabled." What's happening?</p>
-            </div>
-            <div class="quiz-options">
-              <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>AMD GPUs are inherently 4.7x slower than NVIDIA</span></button>
-              <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The model architecture is different on ROCm</span></button>
-              <button class="quiz-option" data-value="c" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>The PyTorch Inductor compiler backend crashes on ROCm, so the system falls back to unoptimized execution</span></button>
-            </div>
-            <div class="quiz-feedback" data-correct-text="You nailed it! This is a real issue in the codebase right now. torch.compile with the Inductor backend crashes on ROCm, so the system falls back to eager mode (7.1% MFU vs 33.7% on CUDA). The fix is being tracked as a PR." data-incorrect-text="The MI300X is actually very powerful hardware. The 4.7x gap comes from torch.compile being disabled on ROCm due to an Inductor backend crash &mdash; the system falls back to unoptimized execution. This is a real, active issue in the codebase."></div>
-          </div>
-          <button class="quiz-check-btn" onclick="checkQuiz('quiz-m7')">Check Answer</button>
-        </div>
-      </section>
-    </div>
-  </div>
-</section>
-
-<!-- ============================================================
-     JAVASCRIPT
-     ============================================================ -->
-<script>
-(function() {
-  'use strict';
-
-  // ========== SCROLL & NAV ==========
-  const progressBar = document.getElementById('progress-bar');
-  const navDots = document.querySelectorAll('.nav-dot');
-  const modules = document.querySelectorAll('.module');
-
-  function updateProgress() {
-    const scrollTop = window.scrollY;
-    const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
-    const progress = scrollHeight > 0 ? (scrollTop / scrollHeight) * 100 : 0;
-    progressBar.style.width = progress + '%';
-
-    // Update nav dots
-    let currentIdx = 0;
-    modules.forEach((mod, i) => {
-      const rect = mod.getBoundingClientRect();
-      if (rect.top <= window.innerHeight / 3) currentIdx = i;
-    });
-    navDots.forEach((dot, i) => {
-      dot.classList.remove('active');
-      if (i < currentIdx) dot.classList.add('visited');
-      if (i === currentIdx) dot.classList.add('active');
-    });
-  }
-  window.addEventListener('scroll', () => requestAnimationFrame(updateProgress), { passive: true });
-
-  navDots.forEach(dot => {
-    dot.addEventListener('click', () => {
-      const target = document.getElementById(dot.dataset.target);
-      if (target) target.scrollIntoView({ behavior: 'smooth' });
-    });
-  });
-
-  // Keyboard nav
-  document.addEventListener('keydown', (e) => {
-    if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
-    const modArray = Array.from(modules);
-    let current = 0;
-    modArray.forEach((m, i) => { if (m.getBoundingClientRect().top <= 100) current = i; });
-    if ((e.key === 'ArrowDown' || e.key === 'ArrowRight') && current < modArray.length - 1) {
-      modArray[current + 1].scrollIntoView({ behavior: 'smooth' }); e.preventDefault();
-    }
-    if ((e.key === 'ArrowUp' || e.key === 'ArrowLeft') && current > 0) {
-      modArray[current - 1].scrollIntoView({ behavior: 'smooth' }); e.preventDefault();
-    }
-  });
-
-  // ========== SCROLL REVEAL ==========
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) { entry.target.classList.add('visible'); observer.unobserve(entry.target); }
-    });
-  }, { rootMargin: '0px 0px -10% 0px', threshold: 0.1 });
-  document.querySelectorAll('.animate-in').forEach(el => observer.observe(el));
-
-  // Stagger
-  document.querySelectorAll('.stagger-children').forEach(parent => {
-    Array.from(parent.children).forEach((child, i) => {
-      if (!child.style.getPropertyValue('--stagger-index')) child.style.setProperty('--stagger-index', i);
-    });
-  });
-
-  // ========== TRAINING FLOW ==========
-  const ftSteps = [
-    { highlight: 'ft-data', label: 'Data Loader reads text from ClimbMix parquet files and packs it into batches' },
-    { highlight: 'ft-model', label: 'Neural network processes the batch: embedding → attention → MLP → output' },
-    { highlight: 'ft-model', label: 'Model predicts the next word, compares to the real answer, and calculates the "loss" (error)' },
-    { highlight: 'ft-optim', label: 'Optimizer reads the loss gradient and adjusts all parameters to reduce the error' },
-    { highlight: 'ft-data', label: 'Loop! Load next batch. Repeat hundreds of times in 5 minutes.' },
-    { highlight: 'ft-eval', label: 'Time\'s up! Evaluator measures val_bpb on held-out text to see how well the model learned.' },
-  ];
-  let ftStep = 0;
-  window.ftNext = function() {
-    if (ftStep >= ftSteps.length) return;
-    const s = ftSteps[ftStep];
-    document.querySelectorAll('#flow-training .flow-actor').forEach(a => a.classList.remove('active'));
-    document.getElementById(s.highlight).classList.add('active');
-    document.getElementById('ft-label').textContent = s.label;
-    ftStep++;
-    document.getElementById('ft-progress').textContent = 'Step ' + ftStep + ' / ' + ftSteps.length;
-  };
-  window.ftReset = function() {
-    ftStep = 0;
-    document.querySelectorAll('#flow-training .flow-actor').forEach(a => a.classList.remove('active'));
-    document.getElementById('ft-label').textContent = 'Click "Next Step" to see the training loop';
-    document.getElementById('ft-progress').textContent = 'Step 0 / ' + ftSteps.length;
-  };
-
-  // ========== CHAT ANIMATION ==========
-  const chats = {};
-  function initChat(id) {
-    const msgs = document.querySelectorAll('#chat-' + id + '-msgs .chat-message');
-    chats[id] = { msgs, index: 0 };
-  }
-  initChat('cast');
-
-  const chatActors = {
-    'orch': { initials: 'O', color: 'var(--color-actor-1)' },
-    'claude': { initials: 'C', color: 'var(--color-actor-2)' },
-    'trainer': { initials: 'T', color: 'var(--color-actor-3)' },
-    'git': { initials: 'G', color: 'var(--color-actor-4)' },
-    'results': { initials: 'R', color: 'var(--color-actor-5)' },
-  };
-
-  window.playChatNext = function(id) {
-    const c = chats[id]; if (!c || c.index >= c.msgs.length) return;
-    const msg = c.msgs[c.index];
-    const sender = msg.dataset.sender;
-    const typing = document.getElementById('chat-' + id + '-typing');
-    const avatar = document.getElementById(id + '-typing-avatar');
-    if (chatActors[sender]) {
-      avatar.textContent = chatActors[sender].initials;
-      avatar.style.background = chatActors[sender].color;
-    }
-    typing.style.display = 'flex';
-    setTimeout(() => {
-      typing.style.display = 'none';
-      msg.style.display = 'flex';
-      msg.style.animation = 'fadeSlideUp 0.3s var(--ease-out)';
-      c.index++;
-      document.getElementById('chat-' + id + '-progress').textContent = c.index + ' / ' + c.msgs.length + ' messages';
-      // Auto-scroll
-      const container = document.getElementById('chat-' + id + '-msgs');
-      container.scrollTop = container.scrollHeight;
-    }, 800);
-  };
-
-  window.playChatAll = function(id) {
-    const c = chats[id]; if (!c) return;
-    const interval = setInterval(() => {
-      if (c.index >= c.msgs.length) { clearInterval(interval); return; }
-      playChatNext(id);
-    }, 1400);
-  };
-
-  window.resetChat = function(id) {
-    const c = chats[id]; if (!c) return;
-    c.index = 0;
-    c.msgs.forEach(m => { m.style.display = 'none'; m.style.animation = ''; });
-    document.getElementById('chat-' + id + '-progress').textContent = '0 / ' + c.msgs.length + ' messages';
-  };
-
-  // ========== QUIZ ==========
-  window.selectOption = function(btn) {
-    const block = btn.closest('.quiz-question-block');
-    block.querySelectorAll('.quiz-option').forEach(o => o.classList.remove('selected'));
-    btn.classList.add('selected');
-  };
-
-  window.checkQuiz = function(sectionId) {
-    const container = document.getElementById(sectionId);
-    const questions = container.querySelectorAll('.quiz-question-block');
-    questions.forEach(q => {
-      const selected = q.querySelector('.quiz-option.selected');
-      const feedback = q.querySelector('.quiz-feedback');
-      const correctValue = q.dataset.correct;
-      if (!selected) { feedback.innerHTML = 'Pick an answer first!'; feedback.className = 'quiz-feedback show error'; return; }
-      if (selected.dataset.value === correctValue) {
-        selected.classList.add('correct');
-        feedback.innerHTML = '<strong>Exactly!</strong> ' + feedback.dataset.correctText;
-        feedback.className = 'quiz-feedback show success';
-      } else {
-        selected.classList.add('incorrect');
-        q.querySelector('[data-value="' + correctValue + '"]').classList.add('correct');
-        feedback.innerHTML = '<strong>Not quite.</strong> ' + feedback.dataset.incorrectText;
-        feedback.className = 'quiz-feedback show error';
-      }
-      q.querySelectorAll('.quiz-option').forEach(o => { o.style.pointerEvents = 'none'; });
-    });
-  };
-
-  // ========== ARCH DIAGRAM ==========
-  window.showArchDesc = function(el) {
-    document.querySelectorAll('.arch-component').forEach(c => c.classList.remove('selected'));
-    el.classList.add('selected');
-    const desc = el.closest('.arch-diagram').querySelector('.arch-description');
-    desc.textContent = el.dataset.desc;
-    desc.style.background = 'var(--color-accent-light)';
-    desc.style.color = 'var(--color-text)';
-  };
-
-  // ========== GLOSSARY TOOLTIPS ==========
-  let activeTooltip = null;
-  function positionTooltip(term, tip) {
-    const rect = term.getBoundingClientRect();
-    const tipWidth = Math.min(320, window.innerWidth * 0.8);
-    tip.style.width = tipWidth + 'px';
-    let left = rect.left + rect.width / 2 - tipWidth / 2;
-    left = Math.max(8, Math.min(left, window.innerWidth - tipWidth - 8));
-    tip.style.left = left + 'px';
-    document.body.appendChild(tip);
-    const tipHeight = tip.offsetHeight;
-    if (rect.top - tipHeight - 8 < 0) {
-      tip.style.top = (rect.bottom + 8) + 'px';
-      tip.classList.add('flip');
-    } else {
-      tip.style.top = (rect.top - tipHeight - 8) + 'px';
-      tip.classList.remove('flip');
-    }
-  }
-
-  document.querySelectorAll('.term').forEach(term => {
-    const tip = document.createElement('span');
-    tip.className = 'term-tooltip';
-    tip.textContent = term.dataset.definition;
-
-    term.addEventListener('mouseenter', () => {
-      if (activeTooltip && activeTooltip !== tip) { activeTooltip.classList.remove('visible'); activeTooltip.remove(); }
-      positionTooltip(term, tip);
-      requestAnimationFrame(() => tip.classList.add('visible'));
-      activeTooltip = tip;
-    });
-    term.addEventListener('mouseleave', () => {
-      tip.classList.remove('visible');
-      setTimeout(() => { if (!tip.classList.contains('visible')) tip.remove(); }, 150);
-      activeTooltip = null;
-    });
-    term.addEventListener('click', (e) => {
-      e.stopPropagation();
-      if (activeTooltip && activeTooltip !== tip) { activeTooltip.classList.remove('visible'); activeTooltip.remove(); }
-      if (tip.classList.contains('visible')) { tip.classList.remove('visible'); tip.remove(); activeTooltip = null; }
-      else { positionTooltip(term, tip); requestAnimationFrame(() => tip.classList.add('visible')); activeTooltip = tip; }
-    });
-  });
-  document.addEventListener('click', () => {
-    if (activeTooltip) { activeTooltip.classList.remove('visible'); activeTooltip.remove(); activeTooltip = null; }
-  });
-
-  // Initial update
-  updateProgress();
-})();
-</script>
 </body>
 </html>

--- a/docs/shared.css
+++ b/docs/shared.css
@@ -1,0 +1,95 @@
+/* ============================================================
+   AUTORESEARCH-UNIFIED — Shared Site Chrome
+   Site navigation bar + footer used across all pages.
+   ============================================================ */
+
+/* ---- Site Nav ---- */
+.site-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  height: 50px;
+  background: rgba(250, 247, 242, 0.95);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid #E5DFD6;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  font-family: 'DM Sans', -apple-system, sans-serif;
+}
+
+.site-nav-brand {
+  font-family: 'Bricolage Grotesque', Georgia, serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: #2C2A28;
+  text-decoration: none;
+}
+.site-nav-brand:hover {
+  color: #2A7B9B;
+  text-decoration: none;
+}
+
+.site-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.site-nav-links a {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #6B6560;
+  text-decoration: none;
+  transition: color 150ms ease;
+}
+.site-nav-links a:hover,
+.site-nav-links a.active {
+  color: #2A7B9B;
+}
+.site-nav-links a.active {
+  border-bottom: 2px solid #2A7B9B;
+  padding-bottom: 2px;
+}
+
+/* External link icon */
+.site-nav-links a[target="_blank"]::after {
+  content: " \2197";
+  font-size: 0.7em;
+  vertical-align: super;
+}
+
+/* ---- Site Footer ---- */
+.site-footer {
+  border-top: 1px solid #E5DFD6;
+  background: #FAF7F2;
+  padding: 1.5rem 24px;
+  text-align: center;
+  font-family: 'DM Sans', -apple-system, sans-serif;
+  font-size: 0.8rem;
+  color: #9E9790;
+}
+.site-footer a {
+  color: #6B6560;
+  text-decoration: none;
+  margin: 0 0.5rem;
+}
+.site-footer a:hover {
+  color: #2A7B9B;
+  text-decoration: underline;
+}
+
+/* ---- Mobile ---- */
+@media (max-width: 600px) {
+  .site-nav { padding: 0 16px; }
+  .site-nav-brand { font-size: 1rem; }
+  .site-nav-links { gap: 0.75rem; }
+  .site-nav-links a { font-size: 0.8rem; }
+}


### PR DESCRIPTION
## Summary
- Adds a **landing hub page** at `/` with card-based navigation to all project artifacts (benchmark leaderboard, interactive course, HuggingFace dataset, wiki, source code)
- Moves the **interactive course** from `/` to `/course/` to make room for the hub
- Adds a **shared site navigation bar** (`shared.css`) across all pages — warm-themed chrome that provides visual coherence while letting each page keep its own content theme
- Integrates site nav and footer into the **benchmark leaderboard** page (from PR #30)
- Updates README course links to the new `/course/` path

## URL structure
| Path | Content |
|------|---------|
| `/` | Hub landing page with artifact cards |
| `/benchmark/` | LLM benchmark leaderboard |
| `/course/` | Interactive course (7 modules) |

## Test plan
- [ ] Verify hub page renders at `elementalcollision.github.io/autoresearch-unified/`
- [ ] Verify benchmark loads at `/benchmark/` with data and charts working
- [ ] Verify course loads at `/course/` with scroll-snap navigation working
- [ ] Test cross-navigation: hub → benchmark → course → hub via nav bar
- [ ] Verify `elementalcollision.github.io` org-level link still resolves correctly
- [ ] Check mobile responsiveness on all three pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)