### PR TITLE
Fix API validation min token error for OpenRouter/GPT-4.1

### DIFF
--- a/tui/llm_backend.py
+++ b/tui/llm_backend.py
@@ -221,7 +221,7 @@ class ClaudeBackend(LLMBackend):
             import anthropic
             self._client.messages.create(
                 model=self._model,
-                max_tokens=5,
+                max_tokens=16,
                 messages=[{"role": "user", "content": "Say OK"}],
             )
             return True
@@ -291,7 +291,7 @@ class OpenAIBackend(LLMBackend):
             from openai import AuthenticationError
             self._client.chat.completions.create(
                 model=self._model,
-                max_tokens=5,
+                max_tokens=16,
                 messages=[{"role": "user", "content": "Say OK"}],
             )
             return True
@@ -380,7 +380,7 @@ class AzureOpenAIBackend(LLMBackend):
             from openai import AuthenticationError
             self._client.chat.completions.create(
                 model=self._deployment,
-                max_tokens=5,
+                max_tokens=16,
                 messages=[{"role": "user", "content": "Say OK"}],
             )
             return True
@@ -467,7 +467,7 @@ class OpenRouterBackend(LLMBackend):
             from openai import AuthenticationError
             self._client.chat.completions.create(
                 model=self._model,
-                max_tokens=5,
+                max_tokens=16,
                 messages=[{"role": "user", "content": "Say OK"}],
             )
             return True


### PR DESCRIPTION
## Summary
- Validation calls in all 4 LLM backend classes (ClaudeBackend, OpenAIBackend, AzureOpenAIBackend, OpenRouterBackend) used `max_tokens=5` for their test API calls
- OpenRouter's GPT-4.1 provider requires `max_output_tokens >= 16`, causing validation to fail with: *"Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 5 instead."*
- Bumped all 4 validation calls to `max_tokens=16`

## Discovery
Found during the power instrumentation validation run on RunPod RTX 5090. The headless runner failed on startup before any experiments could run. Already hotfixed on the RunPod instance; this PR merges the fix to main.

## Test plan
- [x] OpenRouter GPT-4.1 validation passes (confirmed on RunPod RTX 5090)
- [ ] Claude backend validation still works
- [ ] OpenAI/Azure backends unaffected (16 is well within their limits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)