### PR TITLE
Implement strategy diversity enhancements 1-3

### DIFF
--- a/tests/test_strategy_diversity.py
+++ b/tests/test_strategy_diversity.py
@@ -1,0 +1,274 @@
+"""Tests for strategy diversity enhancements (PR #25 implementation).
+
+Covers:
+- Experiment classification into strategy categories
+- Category summary in formatted history
+- Stagnation detection logic
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tui.results import (
+    ExperimentResult,
+    append_result,
+    categorize_experiments,
+    classify_experiment,
+    format_history_for_prompt,
+    init_results_tsv,
+    load_results,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_experiment
+# ---------------------------------------------------------------------------
+
+class TestClassifyExperiment:
+    def test_lr_changes(self):
+        assert classify_experiment("Increase MATRIX_LR from 0.04 to 0.06") == "learning_rate"
+        assert classify_experiment("Lower SCALAR_LR to 0.5") == "learning_rate"
+        assert classify_experiment("Reduce EMBEDDING_LR from 0.6 to 0.3") == "learning_rate"
+        assert classify_experiment("Bump learning rate by 10%") == "learning_rate"
+
+    def test_batch_size(self):
+        assert classify_experiment("Halve TOTAL_BATCH_SIZE from 2^19 to 2^18") == "batch_size"
+        assert classify_experiment("Reduce batch size to 32") == "batch_size"
+        assert classify_experiment("Double TOTAL_BATCH_SIZE") == "batch_size"
+
+    def test_architecture(self):
+        assert classify_experiment("Increase DEPTH from 8 to 12") == "architecture"
+        assert classify_experiment("Change HEAD_DIM from 64 to 128") == "architecture"
+        assert classify_experiment("Set WINDOW_PATTERN to SSLL") == "architecture"
+        assert classify_experiment("Adjust MLP_RATIO to 3.0") == "architecture"
+        assert classify_experiment("Modify ASPECT_RATIO") == "architecture"
+
+    def test_schedule(self):
+        assert classify_experiment("Set WARMUP_RATIO to 0.05") == "schedule"
+        assert classify_experiment("Reduce WARMDOWN_RATIO from 0.5 to 0.3") == "schedule"
+        assert classify_experiment("Set FINAL_LR_FRAC to 0.1") == "schedule"
+
+    def test_regularization(self):
+        assert classify_experiment("Reduce WEIGHT_DECAY from 0.2 to 0.1") == "regularization"
+        assert classify_experiment("Tune ADAM_BETAS to (0.9, 0.95)") == "regularization"
+
+    def test_infrastructure(self):
+        assert classify_experiment("Enable ACTIVATION_CHECKPOINTING") == "infrastructure"
+        assert classify_experiment("Change COMPILE_MODE to reduce-overhead") == "infrastructure"
+
+    def test_other(self):
+        assert classify_experiment("baseline (no modifications)") == "other"
+        assert classify_experiment("Something completely different") == "other"
+
+    def test_batch_beats_lr_when_both_present(self):
+        # "batch_size" is checked before "learning_rate" in the function
+        assert classify_experiment("Change batch_size and _lr together") == "batch_size"
+
+
+# ---------------------------------------------------------------------------
+# categorize_experiments
+# ---------------------------------------------------------------------------
+
+class TestCategorizeExperiments:
+    def test_empty(self):
+        assert categorize_experiments([]) == {}
+
+    def test_skips_baseline(self):
+        results = [
+            ExperimentResult(
+                exp="exp0", description="baseline (no modifications)",
+                val_bpb=1.1, peak_mem_gb=8.0, tok_sec=30000, mfu=20.0,
+                steps=500, status="baseline", notes="",
+            ),
+        ]
+        assert categorize_experiments(results) == {}
+
+    def test_mixed_categories(self):
+        results = [
+            ExperimentResult(
+                exp="exp0", description="baseline", val_bpb=1.1,
+                peak_mem_gb=8.0, tok_sec=30000, mfu=20.0, steps=500,
+                status="baseline", notes="",
+            ),
+            ExperimentResult(
+                exp="exp1", description="Increase MATRIX_LR to 0.06",
+                val_bpb=1.08, peak_mem_gb=8.0, tok_sec=30000, mfu=20.0,
+                steps=500, status="keep", notes="",
+            ),
+            ExperimentResult(
+                exp="exp2", description="Halve TOTAL_BATCH_SIZE",
+                val_bpb=1.05, peak_mem_gb=4.0, tok_sec=30000, mfu=20.0,
+                steps=1000, status="keep", notes="",
+            ),
+            ExperimentResult(
+                exp="exp3", description="Increase MATRIX_LR to 0.08",
+                val_bpb=1.12, peak_mem_gb=8.0, tok_sec=30000, mfu=20.0,
+                steps=500, status="discard", notes="",
+            ),
+        ]
+        cats = categorize_experiments(results)
+        assert cats["learning_rate"] == 2
+        assert cats["batch_size"] == 1
+
+
+# ---------------------------------------------------------------------------
+# format_history_for_prompt — strategy summary footer
+# ---------------------------------------------------------------------------
+
+class TestFormatHistoryStrategyFooter:
+    def test_no_results(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        assert format_history_for_prompt(path) == "No experiments yet."
+
+    def test_baseline_only_no_summary(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        init_results_tsv(path)
+        append_result(path, ExperimentResult(
+            exp="exp0", description="baseline (no modifications)",
+            val_bpb=1.1, peak_mem_gb=8.0, tok_sec=30000, mfu=20.0,
+            steps=500, status="baseline", notes="",
+        ))
+        text = format_history_for_prompt(path)
+        # baseline-only runs should show the table but "other" is skipped
+        # because classify returns "other" for baseline, and baseline status
+        # is filtered out of categorize_experiments
+        assert "Strategy summary" not in text
+
+    def test_shows_category_counts(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        init_results_tsv(path)
+        append_result(path, ExperimentResult(
+            exp="exp0", description="baseline", val_bpb=1.1,
+            peak_mem_gb=8.0, tok_sec=30000, mfu=20.0, steps=500,
+            status="baseline", notes="",
+        ))
+        append_result(path, ExperimentResult(
+            exp="exp1", description="Increase MATRIX_LR to 0.06",
+            val_bpb=1.08, peak_mem_gb=8.0, tok_sec=30000, mfu=20.0,
+            steps=500, status="keep", notes="",
+        ))
+        append_result(path, ExperimentResult(
+            exp="exp2", description="Halve TOTAL_BATCH_SIZE",
+            val_bpb=0.0, peak_mem_gb=0.0, tok_sec=0, mfu=0.0,
+            steps=0, status="crash", notes="OOM",
+        ))
+
+        text = format_history_for_prompt(path)
+        assert "Strategy summary" in text
+        assert "learning_rate: 1 tried, 1 kept" in text
+        assert "batch_size: 1 tried, 0 kept" in text
+
+
+# ---------------------------------------------------------------------------
+# Stagnation detection (orchestrator)
+# ---------------------------------------------------------------------------
+
+class TestStagnationDetection:
+    """Test _detect_stagnation via the orchestrator.
+
+    We construct a results.tsv file and call the method directly,
+    avoiding the need to mock the LLM or training subprocess.
+    """
+
+    def _make_orchestrator(self, results_path):
+        """Create a minimal orchestrator pointing at a test results file."""
+        # Import here to avoid module-level hardware detection
+        with patch("tui.orchestrator.get_hardware_summary", return_value={}), \
+             patch("tui.orchestrator.GitManager"):
+            from tui.orchestrator import ExperimentOrchestrator
+            orch = ExperimentOrchestrator.__new__(ExperimentOrchestrator)
+            orch._results_path = results_path
+            return orch
+
+    def _populate_results(self, path, descriptions, statuses):
+        """Write a results.tsv with the given descriptions and statuses."""
+        init_results_tsv(path)
+        for i, (desc, status) in enumerate(zip(descriptions, statuses)):
+            append_result(path, ExperimentResult(
+                exp=f"exp{i}", description=desc,
+                val_bpb=1.1 if status != "crash" else 0.0,
+                peak_mem_gb=8.0, tok_sec=30000, mfu=20.0,
+                steps=500 if status != "crash" else 0,
+                status=status, notes="",
+            ))
+
+    def test_no_stagnation_under_15(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        descs = [f"Increase MATRIX_LR to 0.0{i}" for i in range(10)]
+        statuses = ["discard"] * 10
+        self._populate_results(path, descs, statuses)
+
+        orch = self._make_orchestrator(path)
+        assert orch._detect_stagnation() is None
+
+    def test_no_stagnation_with_keeps(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        descs = [f"Increase MATRIX_LR to 0.0{i}" for i in range(15)]
+        statuses = ["keep", "keep", "keep"] + ["discard"] * 12
+        self._populate_results(path, descs, statuses)
+
+        orch = self._make_orchestrator(path)
+        assert orch._detect_stagnation() is None
+
+    def test_stagnation_detected_lr_heavy(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        # 15 experiments, only 1 keep, 10 are LR changes
+        descs = (
+            ["Increase MATRIX_LR to 0.06"] * 10
+            + ["Increase DEPTH to 12"] * 5
+        )
+        statuses = ["keep"] + ["discard"] * 14
+        self._populate_results(path, descs, statuses)
+
+        orch = self._make_orchestrator(path)
+        nudge = orch._detect_stagnation()
+        assert nudge is not None
+        assert "exhausted" in nudge
+        assert "batch size" in nudge.lower()
+
+    def test_no_stagnation_diverse_strategies(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        # 15 experiments, only 1 keep, but diverse strategies (only 3 LR)
+        descs = (
+            ["Increase MATRIX_LR to 0.06"] * 3
+            + ["Halve TOTAL_BATCH_SIZE"] * 3
+            + ["Increase DEPTH to 12"] * 3
+            + ["Set WARMUP_RATIO to 0.05"] * 3
+            + ["Reduce WEIGHT_DECAY to 0.1"] * 3
+        )
+        statuses = ["keep"] + ["discard"] * 14
+        self._populate_results(path, descs, statuses)
+
+        orch = self._make_orchestrator(path)
+        assert orch._detect_stagnation() is None
+
+
+# ---------------------------------------------------------------------------
+# System prompt contains strategy hints
+# ---------------------------------------------------------------------------
+
+class TestSystemPromptStrategyHints:
+    def test_strategy_guidance_present(self):
+        _FAKE_HW = {
+            "chip_name": "Test GPU",
+            "memory_gb": 16,
+            "gpu_cores": 64,
+            "peak_tflops": 10.0,
+            "chip_tier": "test",
+        }
+        with patch("backends.get_hardware_info", return_value=_FAKE_HW):
+            from tui.llm_backend import get_system_prompt
+            prompt = get_system_prompt(_FAKE_HW)
+
+        assert "Strategy guidance" in prompt
+        assert "ADAM_BETAS" in prompt
+        assert "WARMUP_RATIO" in prompt
+        assert "TOTAL_BATCH_SIZE" in prompt
+        assert "halving batch = 2x steps" in prompt
+        assert "ACTIVATION_CHECKPOINTING" in prompt

--- a/tui/llm_backend.py
+++ b/tui/llm_backend.py
@@ -87,6 +87,14 @@ Rules:
 - The key insight from prior characterization: maximizing gradient steps within the fixed time budget is the dominant factor. Smaller batches = more steps = usually better, up to a point.
 - Platform-specific: {platform_notes} {memory_note}
 
+Strategy guidance (use the full repertoire, not just learning rate tuning):
+- Learning rates: MATRIX_LR, SCALAR_LR, EMBEDDING_LR, UNEMBEDDING_LR
+- Regularization: WEIGHT_DECAY, ADAM_BETAS (beta1, beta2)
+- Schedule shape: WARMUP_RATIO (try >0), WARMDOWN_RATIO, FINAL_LR_FRAC (try >0)
+- Architecture: DEPTH, ASPECT_RATIO, HEAD_DIM, MLP_RATIO, WINDOW_PATTERN
+- Throughput: TOTAL_BATCH_SIZE, DEVICE_BATCH_SIZE (halving batch = 2x steps = often big wins)
+- Untried levers: ACTIVATION_CHECKPOINTING (enables deeper models), COMPILE_MODE
+
 Respond in EXACTLY this format (no markdown fences around the whole response):
 
 DESCRIPTION: <one-line description, e.g. "Increase MATRIX_LR from 0.04 to 0.06">

--- a/tui/orchestrator.py
+++ b/tui/orchestrator.py
@@ -32,6 +32,7 @@ from tui.resilience import Heartbeat
 from tui.results import (
     ExperimentResult,
     append_result,
+    classify_experiment,
     format_history_for_prompt,
     get_best_result,
     init_results_tsv,
@@ -516,6 +517,45 @@ class ExperimentOrchestrator:
         self._cb_stats_update()
 
     # ------------------------------------------------------------------
+    # Stagnation detection
+    # ------------------------------------------------------------------
+
+    def _detect_stagnation(self) -> str | None:
+        """Detect if the LLM is stuck in a narrow strategy space.
+
+        Looks at the last 15 experiments. If very few were kept and
+        most were learning rate changes, returns a nudge message to
+        append to the prompt. Otherwise returns None.
+        """
+        results = load_results(self._results_path)
+        if len(results) < 15:
+            return None
+
+        recent = results[-15:]
+        recent_keeps = sum(1 for r in recent if r.status == "keep")
+
+        if recent_keeps > 1:
+            return None
+
+        # Count how many recent experiments were learning rate changes
+        lr_count = sum(
+            1 for r in recent
+            if r.status != "baseline"
+            and classify_experiment(r.description) == "learning_rate"
+        )
+
+        if lr_count >= 8:
+            return (
+                "\n\nIMPORTANT: The last 15 experiments have yielded only "
+                f"{recent_keeps} improvement(s), and {lr_count} were learning rate changes. "
+                "Learning rate tuning appears exhausted. Try a fundamentally different "
+                "approach: batch size changes, architectural modifications (DEPTH, "
+                "WINDOW_PATTERN, HEAD_DIM), or schedule shape changes (WARMUP_RATIO>0, "
+                "FINAL_LR_FRAC>0, ADAM_BETAS)."
+            )
+        return None
+
+    # ------------------------------------------------------------------
     # Single experiment
     # ------------------------------------------------------------------
 
@@ -540,6 +580,11 @@ class ExperimentOrchestrator:
 
         current_code = self._extract_hp_block()
         results_history = format_history_for_prompt(self._results_path)
+
+        # Append stagnation nudge if the LLM is stuck in a narrow strategy space
+        nudge = self._detect_stagnation()
+        if nudge:
+            results_history += nudge
 
         proposal = self._call_llm_with_backoff(
             current_code, results_history, exp_num

--- a/tui/results.py
+++ b/tui/results.py
@@ -145,8 +145,55 @@ def next_experiment_number(path: str = "results.tsv") -> int:
     return max_num + 1
 
 
+def classify_experiment(description: str) -> str:
+    """Classify an experiment description into a strategy category.
+
+    Returns a short category label based on which hyperparameter was changed.
+    Used for strategy summaries in the LLM prompt.
+    """
+    desc = description.lower()
+
+    # Order matters: check more specific patterns first
+    if any(k in desc for k in ["batch_size", "batch size", "total_batch"]):
+        return "batch_size"
+    if any(k in desc for k in ["depth", "head_dim", "window_pattern",
+                                "window pattern", "mlp_ratio", "aspect_ratio"]):
+        return "architecture"
+    if any(k in desc for k in ["warmup", "warmdown", "final_lr_frac",
+                                "schedule", "cooldown"]):
+        return "schedule"
+    if any(k in desc for k in ["weight_decay", "weight decay", "adam_beta",
+                                "regularization"]):
+        return "regularization"
+    if any(k in desc for k in ["_lr", "learning rate", "learning_rate",
+                                "matrix_lr", "scalar_lr", "embedding_lr"]):
+        return "learning_rate"
+    if any(k in desc for k in ["activation_checkpointing", "compile_mode",
+                                "compile mode"]):
+        return "infrastructure"
+
+    return "other"
+
+
+def categorize_experiments(
+    results: list[ExperimentResult],
+) -> dict[str, int]:
+    """Count experiments per strategy category."""
+    counts: dict[str, int] = {}
+    for r in results:
+        if r.status == "baseline":
+            continue
+        cat = classify_experiment(r.description)
+        counts[cat] = counts.get(cat, 0) + 1
+    return counts
+
+
 def format_history_for_prompt(path: str = "results.tsv") -> str:
-    """Format results as a readable table for the LLM prompt."""
+    """Format results as a readable table for the LLM prompt.
+
+    Includes a strategy summary footer so the LLM can see which
+    categories have been explored and which are underrepresented.
+    """
     results = load_results(path)
     if not results:
         return "No experiments yet."
@@ -161,5 +208,17 @@ def format_history_for_prompt(path: str = "results.tsv") -> str:
             f"{r.exp:<6} {r.status:<9} {bpb_str:>8} {r.peak_mem_gb:>7.1f} "
             f"{r.tok_sec:>8} {r.mfu:>5.1f}% {r.steps:>6}  {r.description}"
         )
+
+    # Strategy summary footer
+    categories = categorize_experiments(results)
+    if categories:
+        lines.append("")
+        lines.append("Strategy summary (category: tried / kept):")
+        for cat, count in sorted(categories.items()):
+            kept = sum(
+                1 for r in results
+                if r.status == "keep" and classify_experiment(r.description) == cat
+            )
+            lines.append(f"  {cat}: {count} tried, {kept} kept")
 
     return "\n".join(lines)


### PR DESCRIPTION
## Summary

Implements the first three enhancements from the strategy diversity proposal (PR #25, `docs/enhancement-strategy-diversity.md`):

- **Enhancement 1 -- Strategy hints in system prompt** (`tui/llm_backend.py`): Adds an explicit "strategy menu" listing all hyperparameter categories (learning rates, regularization, schedule shape, architecture, throughput, infrastructure) so the LLM uses the full repertoire instead of defaulting to LR tuning. Telemetry from the 5090 R1 run showed 51% of proposals were LR/schedule tweaks.

- **Enhancement 2 -- Stagnation detection** (`tui/orchestrator.py`): Adds `_detect_stagnation()` which checks the last 15 experiments. If <=1 were kept and >=8 were learning rate changes, it appends a nudge to the prompt directing the LLM toward unexplored strategies (batch size, architecture, schedule shape). The nudge is injected into `_run_experiment()` before the LLM call.

- **Enhancement 3 -- Category annotations in history** (`tui/results.py`): Adds `classify_experiment()` to categorize each experiment description into one of: `learning_rate`, `batch_size`, `architecture`, `schedule`, `regularization`, `infrastructure`, or `other`. The `format_history_for_prompt()` function now appends a strategy summary footer showing tried/kept counts per category, so the LLM can see its own exploration distribution.

Changes are minimal and non-breaking -- the three modified functions (`get_system_prompt`, `_run_experiment`, `format_history_for_prompt`) extend existing behavior without changing signatures or return types.

## Files changed

| File | Change |
|------|--------|
| `tui/llm_backend.py` | +8 lines: strategy guidance block in system prompt |
| `tui/results.py` | +60 lines: `classify_experiment()`, `categorize_experiments()`, strategy summary footer |
| `tui/orchestrator.py` | +45 lines: `_detect_stagnation()`, nudge injection in `_run_experiment()` |
| `tests/test_strategy_diversity.py` | New: 19 tests covering classification, categorization, history formatting, stagnation detection, and prompt content |

## Test plan

- [x] 19 new tests pass (`pytest tests/test_strategy_diversity.py -v`)
- [x] Full suite passes (151/151, zero regressions)
- [ ] Integration: short headless session (`--max 5`) confirming no regressions
- [ ] Live validation: compare strategy distribution with/without enhancements


🤖 Generated with [Claude Code](https://claude.com/claude-code)