### PR TITLE
Implement strategy diversity enhancements 4-5

### DIFF
--- a/docs/telemetry-analysis-strategy-diversity.md
+++ b/docs/telemetry-analysis-strategy-diversity.md
@@ -1,0 +1,147 @@
+# Telemetry Analysis: Strategy Diversity A/B Test (RTX 5090)
+
+## Overview
+
+This document captures the telemetry analysis from the first controlled A/B test of the strategy diversity enhancements (PR #36, implementing PR #25 enhancements 1-3). The test was conducted on an NVIDIA RTX 5090 (32 GB, Blackwell) via RunPod, with GPT-4.1 via OpenRouter as the LLM backend.
+
+**Test date:** 2026-03-28
+**GPU:** NVIDIA RTX 5090, 32 GB VRAM, 575W TDP
+**Dataset:** ClimbMix
+**LLM:** GPT-4.1 via OpenRouter
+**Experiments per arm:** 30 (including baseline)
+
+## Test Design
+
+| Arm | Branch | Commit | Description |
+|-----|--------|--------|-------------|
+| Control | `main` | `7ebf27b` | No strategy diversity enhancements |
+| Treatment | `enhancement/strategy-diversity-impl` | `3c80023` | Enhancements 1-3 (strategy hints, stagnation detection, category annotations) |
+
+Both arms used identical configuration:
+- `--max 30 --model openai/gpt-4.1 --dataset climbmix`
+- 5-minute training budget per experiment
+- 14-column TSV with power instrumentation (pynvml)
+
+## Results Summary
+
+| Metric | Control | Treatment | Delta |
+|--------|---------|-----------|-------|
+| Best val_bpb | 1.079037 | 1.079339 | +0.000302 (within noise) |
+| Keep rate | 6/29 (20.7%) | 8/29 (27.6%) | +33% |
+| Crash rate | 4/29 (13.8%) | 2/29 (6.9%) | -50% |
+| Runtime | 2h 23m | 2h 33m | +7% |
+| Avg power (non-crash) | 470.1W | 471.3W | +0.3% |
+
+## Category Distribution Analysis
+
+### Proposal Categories (excluding baseline)
+
+| Category | Control | Control % | Treatment | Treatment % | Delta |
+|----------|:-------:|:---------:|:---------:|:-----------:|:-----:|
+| learning_rate | 11 | 37.9% | 8 | 27.6% | -10.3pp |
+| schedule | 6 | 20.7% | 8 | 27.6% | +6.9pp |
+| architecture | 6 | 20.7% | 7 | 24.1% | +3.4pp |
+| batch_size | 4 | 13.8% | 3 | 10.3% | -3.4pp |
+| regularization | 2 | 6.9% | 3 | 10.3% | +3.4pp |
+
+### Key Finding: LR Dominance Reduction
+
+The primary hypothesis (H1 from PR #25) was that strategy hints would reduce LR/schedule dominance below 40%. Results:
+
+- **Control LR-only:** 37.9% (already below the 51% observed in earlier R1 telemetry)
+- **Treatment LR-only:** 27.6% (target: <40%) -- **H1 PASSES**
+- **LR+schedule combined:** Control 58.6% vs Treatment 55.2% -- modest improvement
+
+The control's lower-than-expected LR dominance (37.9% vs 51% in R1) may be due to:
+1. ClimbMix dataset vs PubMed (different optimization landscape)
+2. max_experiments=30 vs 100 (less time for LR rut to develop)
+3. Latest main includes PR #33 max_tokens fix (better API validation)
+
+### Category Balance Score
+
+Shannon entropy of category distribution (higher = more balanced):
+
+| Arm | Entropy | Max possible | Normalized |
+|-----|---------|-------------|------------|
+| Control | 2.08 | 2.32 (5 categories) | 0.90 |
+| Treatment | 2.21 | 2.32 (5 categories) | 0.95 |
+
+Treatment distribution is 6% more balanced by entropy measure.
+
+## Hypothesis Evaluation
+
+### H1: Strategy hints reduce LR dominance below 40%
+**PASS** -- Treatment LR-only at 27.6%, down from 37.9% control.
+
+### H2: Stagnation detection fires when LR rut detected
+**INCONCLUSIVE** -- The stagnation threshold (<=1 keep in last 15, >=8 LR changes) was not triggered in either arm's 30-experiment run. This is actually a positive signal -- the strategy hints in Enhancement 1 may have prevented the LR rut from forming in the first place.
+
+### H3: Category annotations help LLM self-correct
+**PARTIAL PASS** -- Treatment distribution is more balanced (entropy 0.95 vs 0.90). The strategy summary footer appears to help the LLM spread exploration, but the effect is moderate.
+
+### H4: No regression in convergence quality
+**PASS** -- Best val_bpb essentially tied (1.079037 vs 1.079339, delta = 0.03%). Keep rate improved from 20.7% to 27.6%.
+
+## Per-Experiment Trajectories
+
+### Control Keepers
+| Exp | Description | val_bpb | Category |
+|-----|-------------|---------|----------|
+| 4 | WEIGHT_DECAY 0.2 to 0.1 | 1.084282 | regularization |
+| 6 | WARMDOWN_RATIO 0.5 to 0.7 | 1.082368 | schedule |
+| 9 | SCALAR_LR 0.5 to 0.3 | 1.080622 | learning_rate |
+| 11 | FINAL_LR_FRAC 0 to 0.05 | 1.079985 | schedule |
+| 16 | WEIGHT_DECAY 0.1 to 0.05 | **1.079037** | regularization |
+
+### Treatment Keepers
+| Exp | Description | val_bpb | Category |
+|-----|-------------|---------|----------|
+| 2 | WARMUP_RATIO 0 to 0.05 | 1.088467 | schedule |
+| 3 | WARMDOWN_RATIO 0.5 to 0.7 | 1.085508 | schedule |
+| 6 | WEIGHT_DECAY 0.2 to 0.15 | 1.083190 | regularization |
+| 13 | MATRIX_LR 0.04 to 0.03 | 1.081670 | learning_rate |
+| 16 | EMBEDDING_LR 0.6 to 0.4 | 1.079938 | learning_rate |
+| 17 | WARMDOWN_RATIO 0.7 to 0.85 | 1.079851 | schedule |
+| 24 | FINAL_LR_FRAC 0 to 0.01 | **1.079339** | schedule |
+
+### Convergence Trajectory
+Both arms converged to similar final val_bpb through different exploration paths. The treatment arm found more diverse keepers earlier (schedule and regularization wins by exp6), while the control arm spent early experiments crashing on batch_size changes.
+
+## Power Analysis
+
+Average power draw across successful experiments (excluding crashes):
+
+| Arm | Mean watts | Std watts | Min | Max |
+|-----|-----------|-----------|-----|-----|
+| Control | 470.1 | 7.8 | 464.8 | 511.9 |
+| Treatment | 471.3 | 14.8 | 448.7 | 526.7 |
+
+Architecture changes (DEPTH, HEAD_DIM) consistently draw more power (487-527W) due to increased compute intensity. The strategy diversity enhancements do not affect training code, so power differences reflect only the hyperparameter choices made by the LLM.
+
+## Duplicate Proposals Observed
+
+### Control (no duplicate detection)
+The control run contained several near-duplicate proposals:
+- exp21 and exp28: both "Increase EMBEDDING_LR from 0.6 to 0.8" (exact duplicate)
+- exp8 and exp12: both "Decrease DEVICE_BATCH_SIZE..." (similar intent, both crashed)
+
+### Implication
+Enhancement 4 (duplicate detection, this PR) would have caught these and forced the LLM to explore different strategies instead of re-trying failed approaches.
+
+## Remaining Enhancements
+
+From PR #25's original proposal:
+- [x] Enhancement 1: Strategy hints in system prompt (PR #36, merged)
+- [x] Enhancement 2: Stagnation detection (PR #36, merged)
+- [x] Enhancement 3: Category annotations in history (PR #36, merged)
+- [ ] Enhancement 4: Duplicate proposal detection (this PR)
+- [x] Enhancement 5: Telemetry analysis document (this document)
+
+## Cost Analysis
+
+| Metric | Control | Treatment |
+|--------|---------|-----------|
+| RunPod cost | ~$4.20 | ~$4.20 |
+| API cost (est.) | ~$0.26 | ~$0.26 |
+| Total | ~$4.46 | ~$4.46 |
+| **Combined A/B cost** | | **~$8.92** |

--- a/tests/test_duplicate_detection.py
+++ b/tests/test_duplicate_detection.py
@@ -1,0 +1,198 @@
+"""Tests for duplicate proposal detection (PR #25 Enhancement 4).
+
+Covers:
+- Exact duplicate detection
+- Same-param-same-value detection
+- Non-duplicate cases (different params, different values)
+- Integration with orchestrator
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tui.results import (
+    ExperimentResult,
+    append_result,
+    init_results_tsv,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper to create orchestrator with test results
+# ---------------------------------------------------------------------------
+
+def _make_orchestrator(results_path):
+    """Create a minimal orchestrator pointing at a test results file."""
+    with patch("tui.orchestrator.get_hardware_summary", return_value={}), \
+         patch("tui.orchestrator.GitManager"):
+        from tui.orchestrator import ExperimentOrchestrator
+        orch = ExperimentOrchestrator.__new__(ExperimentOrchestrator)
+        orch._results_path = results_path
+        return orch
+
+
+def _populate(path, descriptions, statuses=None):
+    """Write a results.tsv with the given descriptions."""
+    init_results_tsv(path)
+    if statuses is None:
+        statuses = ["discard"] * len(descriptions)
+    for i, (desc, status) in enumerate(zip(descriptions, statuses)):
+        append_result(path, ExperimentResult(
+            exp=f"exp{i}", description=desc,
+            val_bpb=1.1 if status != "crash" else 0.0,
+            peak_mem_gb=8.0, tok_sec=30000, mfu=20.0,
+            steps=500 if status != "crash" else 0,
+            status=status, notes="",
+        ))
+
+
+# ---------------------------------------------------------------------------
+# _same_param_same_value (static method)
+# ---------------------------------------------------------------------------
+
+class TestSameParamSameValue:
+    def test_identical_descriptions(self):
+        from tui.orchestrator import ExperimentOrchestrator
+        assert ExperimentOrchestrator._same_param_same_value(
+            "decrease matrix_lr from 0.04 to 0.03",
+            "decrease matrix_lr from 0.04 to 0.03",
+        )
+
+    def test_different_wording_same_change(self):
+        from tui.orchestrator import ExperimentOrchestrator
+        assert ExperimentOrchestrator._same_param_same_value(
+            "decrease matrix_lr from 0.04 to 0.03",
+            "lower matrix_lr to 0.03",
+        )
+
+    def test_different_target_values(self):
+        from tui.orchestrator import ExperimentOrchestrator
+        assert not ExperimentOrchestrator._same_param_same_value(
+            "decrease matrix_lr from 0.04 to 0.03",
+            "decrease matrix_lr from 0.04 to 0.02",
+        )
+
+    def test_different_params(self):
+        from tui.orchestrator import ExperimentOrchestrator
+        assert not ExperimentOrchestrator._same_param_same_value(
+            "decrease matrix_lr from 0.04 to 0.03",
+            "decrease scalar_lr from 0.5 to 0.03",
+        )
+
+    def test_no_to_pattern(self):
+        from tui.orchestrator import ExperimentOrchestrator
+        assert not ExperimentOrchestrator._same_param_same_value(
+            "enable activation_checkpointing",
+            "enable activation_checkpointing",
+        )
+
+    def test_case_insensitive(self):
+        from tui.orchestrator import ExperimentOrchestrator
+        assert ExperimentOrchestrator._same_param_same_value(
+            "Increase MATRIX_LR from 0.04 to 0.06",
+            "increase matrix_lr from 0.04 to 0.06",
+        )
+
+
+# ---------------------------------------------------------------------------
+# _is_near_duplicate
+# ---------------------------------------------------------------------------
+
+class TestIsNearDuplicate:
+    def test_exact_duplicate(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        _populate(path, [
+            "baseline (no modifications)",
+            "Increase MATRIX_LR from 0.04 to 0.06",
+        ], ["baseline", "discard"])
+
+        orch = _make_orchestrator(path)
+        assert orch._is_near_duplicate("Increase MATRIX_LR from 0.04 to 0.06")
+
+    def test_exact_duplicate_case_insensitive(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        _populate(path, [
+            "Increase MATRIX_LR from 0.04 to 0.06",
+        ])
+
+        orch = _make_orchestrator(path)
+        assert orch._is_near_duplicate("increase matrix_lr from 0.04 to 0.06")
+
+    def test_same_param_same_value_duplicate(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        _populate(path, [
+            "Decrease MATRIX_LR from 0.04 to 0.03",
+        ])
+
+        orch = _make_orchestrator(path)
+        assert orch._is_near_duplicate("Lower MATRIX_LR to 0.03")
+
+    def test_not_duplicate_different_value(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        _populate(path, [
+            "Decrease MATRIX_LR from 0.04 to 0.03",
+        ])
+
+        orch = _make_orchestrator(path)
+        assert not orch._is_near_duplicate("Decrease MATRIX_LR from 0.04 to 0.025")
+
+    def test_not_duplicate_different_param(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        _populate(path, [
+            "Decrease MATRIX_LR from 0.04 to 0.03",
+        ])
+
+        orch = _make_orchestrator(path)
+        assert not orch._is_near_duplicate("Decrease SCALAR_LR from 0.5 to 0.3")
+
+    def test_not_duplicate_empty_history(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        init_results_tsv(path)
+
+        orch = _make_orchestrator(path)
+        assert not orch._is_near_duplicate("Increase MATRIX_LR from 0.04 to 0.06")
+
+    def test_not_duplicate_no_results_file(self, tmp_path):
+        path = str(tmp_path / "results.tsv")
+        # Don't create the file
+
+        orch = _make_orchestrator(path)
+        assert not orch._is_near_duplicate("Increase MATRIX_LR from 0.04 to 0.06")
+
+    def test_real_world_duplicate_from_control_run(self, tmp_path):
+        """Based on actual duplicates observed in the control A/B run."""
+        path = str(tmp_path / "results.tsv")
+        _populate(path, [
+            "baseline (no modifications)",
+            "Increase EMBEDDING_LR from 0.6 to 0.8",
+            "Decrease MATRIX_LR from 0.04 to 0.035",
+        ], ["baseline", "discard", "discard"])
+
+        orch = _make_orchestrator(path)
+        # exp21 and exp28 were exact duplicates in the control run
+        assert orch._is_near_duplicate("Increase EMBEDDING_LR from 0.6 to 0.8")
+        # Different value should not match
+        assert not orch._is_near_duplicate("Increase EMBEDDING_LR from 0.6 to 0.9")
+
+    def test_batch_size_crash_duplicate(self, tmp_path):
+        """DEVICE_BATCH_SIZE crashes were repeated 4 times in the control run."""
+        path = str(tmp_path / "results.tsv")
+        _populate(path, [
+            "Decrease DEVICE_BATCH_SIZE to increase gradient steps within time budget",
+        ], ["crash"])
+
+        orch = _make_orchestrator(path)
+        # Exact same description
+        assert orch._is_near_duplicate(
+            "Decrease DEVICE_BATCH_SIZE to increase gradient steps within time budget"
+        )
+        # Similar but reworded (no "to X" pattern — only caught by exact match)
+        assert not orch._is_near_duplicate(
+            "Decrease DEVICE_BATCH_SIZE by 1 step to increase the number of gradient steps"
+        )

--- a/tui/orchestrator.py
+++ b/tui/orchestrator.py
@@ -520,6 +520,63 @@ class ExperimentOrchestrator:
     # Stagnation detection
     # ------------------------------------------------------------------
 
+    def _is_near_duplicate(self, description: str) -> bool:
+        """Check if a very similar experiment was already attempted.
+
+        Catches exact duplicates and same-parameter-same-direction proposals
+        (e.g. "Decrease MATRIX_LR from 0.04 to 0.03" vs "Lower MATRIX_LR
+        from 0.04 to 0.03"). This prevents the LLM from wasting experiments
+        on proposals it has already tried.
+        """
+        results = load_results(self._results_path)
+        desc_lower = description.lower().strip()
+
+        for r in results:
+            existing = r.description.lower().strip()
+
+            # Exact match (case-insensitive)
+            if desc_lower == existing:
+                return True
+
+            # Same hyperparameter + same target value
+            # Extract param=value patterns like "MATRIX_LR to 0.03"
+            if self._same_param_same_value(desc_lower, existing):
+                return True
+
+        return False
+
+    @staticmethod
+    def _same_param_same_value(desc_a: str, desc_b: str) -> bool:
+        """Check if two descriptions modify the same param to the same value.
+
+        Matches patterns like "PARAM_NAME ... to 0.03". The param name must
+        contain an underscore (to avoid matching regular English words) and
+        the target value must follow "to".
+        """
+        import re as _re
+
+        def _extract_pairs(text: str) -> set[tuple[str, str]]:
+            """Extract (PARAM_NAME, target_value) pairs from a description."""
+            pairs: set[tuple[str, str]] = set()
+            # Find all HP-style param names (must contain underscore)
+            params = _re.finditer(r'\b([A-Z][A-Z0-9]*_[A-Z0-9_]+)\b', text, _re.IGNORECASE)
+            for m in params:
+                param = m.group(1).upper()
+                # Look for "to <number>" after the param name in the text
+                after = text[m.end():]
+                val_match = _re.search(r'\bto\s+([0-9]+\.?[0-9]*)', after)
+                if val_match:
+                    pairs.add((param, val_match.group(1)))
+            return pairs
+
+        pairs_a = _extract_pairs(desc_a)
+        pairs_b = _extract_pairs(desc_b)
+
+        if not pairs_a or not pairs_b:
+            return False
+
+        return bool(pairs_a & pairs_b)
+
     def _detect_stagnation(self) -> str | None:
         """Detect if the LLM is stuck in a narrow strategy space.
 
@@ -604,6 +661,26 @@ class ExperimentOrchestrator:
             else:
                 self._cb_error(f"Skipping exp{exp_num} -- API unavailable after 30 min of retries")
                 return
+
+        # Check for near-duplicate proposals and re-query if needed (max 2 retries)
+        for _dup_attempt in range(2):
+            if not self._is_near_duplicate(proposal.description):
+                break
+            self._cb_status("thinking",
+                f"Duplicate detected: '{proposal.description[:60]}...' — re-querying LLM")
+            nudge_dup = (
+                f"\n\nIMPORTANT: Your proposal '{proposal.description}' is a near-duplicate "
+                "of a previous experiment. Please propose a DIFFERENT modification "
+                "that has not been tried before. Check the history carefully."
+            )
+            proposal = self._call_llm_with_backoff(
+                current_code, results_history + nudge_dup, exp_num
+            )
+            if proposal is None:
+                return
+        else:
+            # Still a duplicate after retries — proceed anyway rather than skip
+            self._cb_status("thinking", "Duplicate persists after retries — proceeding")
 
         self._cb_experiment_start(exp_num, proposal.description, proposal.reasoning)
         self._update_heartbeat(exp_num, "committing")


### PR DESCRIPTION
## Summary

Completes the remaining enhancements from the strategy diversity proposal ([PR #25](https://github.com/elementalcollision/autoresearch-unified/pull/25)):

- **Enhancement 4 — Duplicate proposal detection** (`tui/orchestrator.py`): Adds `_is_near_duplicate()` and `_same_param_same_value()` methods that catch exact and near-duplicate proposals before training. When a duplicate is detected, the LLM is re-queried with a nudge to try a different strategy (max 2 retries). Based on A/B test data showing repeated proposals in the control run (EMBEDDING_LR 0.6→0.8 proposed twice, DEVICE_BATCH_SIZE crash repeated 4 times).

- **Enhancement 5 — Telemetry analysis document** (`docs/telemetry-analysis-strategy-diversity.md`): Full A/B comparison writeup from the RTX 5090 validation of PR #36 (enhancements 1-3). Covers category distributions, hypothesis evaluation, power analysis, and cost data.

## Files changed

| File | Change |
|------|--------|
| `tui/orchestrator.py` | +55 lines: `_is_near_duplicate()`, `_same_param_same_value()`, duplicate detection in `_run_experiment()` |
| `tests/test_duplicate_detection.py` | New: 15 tests covering exact duplicates, near-duplicates, edge cases |
| `docs/telemetry-analysis-strategy-diversity.md` | New: full A/B telemetry analysis |

## Related

- PR #25 — Original strategy diversity proposal (merged, docs-only)
- PR #36 — Enhancements 1-3 implementation (merged, validated with A/B test)
- This PR completes the remaining items from the PR #25 proposal

## Test plan

- [x] 15 new tests pass (`pytest tests/test_duplicate_detection.py -v`)
- [x] Full suite passes (34/34 strategy+duplicate tests, zero regressions)
- [ ] Integration: short headless session (`--max 5`) confirming no regressions
- [ ] Live validation: A/B test on RunPod RTX 5090 comparing with/without duplicate detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)