### PR TITLE
Fix Metal/MLX power monitoring with auto-detect sudo

### DIFF
--- a/backends/power.py
+++ b/backends/power.py
@@ -2,14 +2,13 @@
 
 Provides a background thread that polls GPU/accelerator power draw during
 training. Supports NVIDIA (pynvml / nvidia-smi), AMD ROCm (amdsmi / rocm-smi),
-Apple Silicon (ioreg), and Intel Gaudi (hl-smi).
+Apple Silicon (powermetrics), and Intel Gaudi (hl-smi).
 
 Graceful degradation: if no power API is available, start()/stop() are no-ops
 and stop() returns (0.0, 0.0). Training never crashes due to power monitoring.
 """
 
 import json
-import os
 import re
 import subprocess
 import threading
@@ -204,21 +203,20 @@ class PowerMonitor:
         """Try powermetrics for Apple Silicon GPU power.
 
         Apple Silicon does not expose GPU power counters via unprivileged
-        ioreg queries. The only reliable source is `sudo powermetrics`,
+        ioreg queries. The only reliable source is ``sudo powermetrics``,
         which reads the SoC energy model counters.
 
-        Requires passwordless sudo for the powermetrics binary:
+        Auto-detects whether passwordless sudo is available using
+        ``sudo -n`` (non-interactive mode).  If sudo requires a password,
+        the probe fails immediately and power monitoring silently degrades
+        to (0.0, 0.0).
+
+        To enable, configure passwordless sudo for powermetrics::
+
             sudo visudo -f /etc/sudoers.d/powermetrics
             %staff ALL=(root) NOPASSWD: /usr/bin/powermetrics
-
-        Set AUTORESEARCH_POWERMETRICS_SUDO=1 to enable (disabled by default
-        to avoid hanging on a sudo password prompt during training).
         """
-        if not os.environ.get("AUTORESEARCH_POWERMETRICS_SUDO"):
-            return None
-
         try:
-            # Test that sudo powermetrics works without a password prompt
             result = subprocess.run(
                 ["sudo", "-n", "powermetrics",
                  "--samplers", "gpu_power", "-i", "1000", "-n", "1", "-f", "plist"],
@@ -251,29 +249,6 @@ class PowerMonitor:
             return mj / 1000.0  # millijoules per second = watts (1s interval)
         # Fallback: look for gpu_power in newer powermetrics formats
         m = re.search(r"<key>gpu_power</key>\s*<(?:integer|real)>([\d.]+)</(?:integer|real)>", output)
-        if m:
-            return float(m.group(1)) / 1000.0
-        return 0.0
-
-    @staticmethod
-    def _parse_ioreg_gpu_power(output: str) -> float:
-        """Parse GPU power from ioreg output (milliwatts -> watts)."""
-        # Look for GPU power patterns in ioreg output
-        for pattern in [
-            r'"GPU Power"\s*=\s*(\d+)',
-            r'"gpu-power"\s*=\s*(\d+)',
-            r'"GPUPower"\s*=\s*(\d+)',
-        ]:
-            m = re.search(pattern, output, re.IGNORECASE)
-            if m:
-                mw = float(m.group(1))
-                return mw / 1000.0  # milliwatts to watts
-        return 0.0
-
-    @staticmethod
-    def _parse_agx_power(output: str) -> float:
-        """Parse power from AGXAccelerator ioreg node."""
-        m = re.search(r'"device-power"\s*=\s*(\d+)', output)
         if m:
             return float(m.group(1)) / 1000.0
         return 0.0

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -1,5 +1,8 @@
 """Tests for backends.power -- cross-platform power monitoring."""
+import subprocess
 import time
+from unittest.mock import patch, MagicMock
+
 import pytest
 from backends.power import PowerMonitor
 
@@ -83,3 +86,143 @@ class TestPowerMonitorCalculation:
         # Should have collected some samples despite errors
         assert avg_watts == pytest.approx(100.0, abs=1.0)
         assert total_joules > 0
+
+
+# ---------------------------------------------------------------------------
+# _parse_powermetrics_gpu
+# ---------------------------------------------------------------------------
+
+class TestParsepowermetricsGpu:
+    """Test plist parsing for Apple Silicon powermetrics output."""
+
+    SAMPLE_PLIST = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>gpu</key>
+    <dict>
+        <key>gpu_energy</key>
+        <integer>11235</integer>
+        <key>gpu_busy_ratio</key>
+        <real>0.42</real>
+    </dict>
+</dict>
+</plist>"""
+
+    SAMPLE_PLIST_GPU_POWER = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>gpu</key>
+    <dict>
+        <key>gpu_power</key>
+        <real>8500.0</real>
+    </dict>
+</dict>
+</plist>"""
+
+    def test_parses_gpu_energy(self):
+        """gpu_energy in millijoules → watts (at 1s interval)."""
+        watts = PowerMonitor._parse_powermetrics_gpu(self.SAMPLE_PLIST)
+        assert watts == pytest.approx(11.235, rel=0.01)
+
+    def test_parses_gpu_power_fallback(self):
+        """Falls back to gpu_power key if gpu_energy is absent."""
+        watts = PowerMonitor._parse_powermetrics_gpu(self.SAMPLE_PLIST_GPU_POWER)
+        assert watts == pytest.approx(8.5, rel=0.01)
+
+    def test_empty_output_returns_zero(self):
+        assert PowerMonitor._parse_powermetrics_gpu("") == 0.0
+
+    def test_malformed_plist_returns_zero(self):
+        assert PowerMonitor._parse_powermetrics_gpu("<plist>garbage</plist>") == 0.0
+
+    def test_no_gpu_keys_returns_zero(self):
+        plist = """\
+<plist version="1.0"><dict>
+<key>cpu_energy</key><integer>5000</integer>
+</dict></plist>"""
+        assert PowerMonitor._parse_powermetrics_gpu(plist) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _try_metal_sampler auto-detection
+# ---------------------------------------------------------------------------
+
+class TestMetalSamplerAutoDetect:
+    """Test that _try_metal_sampler auto-detects passwordless sudo."""
+
+    GOOD_PLIST = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>gpu</key><dict>
+<key>gpu_energy</key><integer>15000</integer>
+</dict></dict></plist>"""
+
+    @patch("subprocess.run")
+    def test_returns_sampler_when_sudo_works(self, mock_run):
+        """Returns a callable sampler when sudo powermetrics succeeds."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=self.GOOD_PLIST
+        )
+        monitor = PowerMonitor.__new__(PowerMonitor)
+        monitor._poll_interval = 1.0
+        sampler = monitor._try_metal_sampler()
+        assert sampler is not None
+        assert callable(sampler)
+
+    @patch("subprocess.run")
+    def test_returns_none_when_sudo_fails(self, mock_run):
+        """Returns None when sudo requires a password (returncode != 0)."""
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="sudo: a password is required"
+        )
+        monitor = PowerMonitor.__new__(PowerMonitor)
+        monitor._poll_interval = 1.0
+        assert monitor._try_metal_sampler() is None
+
+    @patch("subprocess.run", side_effect=FileNotFoundError)
+    def test_returns_none_when_powermetrics_missing(self, mock_run):
+        """Returns None on Linux/non-macOS where powermetrics doesn't exist."""
+        monitor = PowerMonitor.__new__(PowerMonitor)
+        monitor._poll_interval = 1.0
+        assert monitor._try_metal_sampler() is None
+
+    @patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="sudo", timeout=10))
+    def test_returns_none_on_timeout(self, mock_run):
+        """Returns None if powermetrics times out (e.g. sudo hangs)."""
+        monitor = PowerMonitor.__new__(PowerMonitor)
+        monitor._poll_interval = 1.0
+        assert monitor._try_metal_sampler() is None
+
+    @patch("subprocess.run")
+    def test_returns_none_when_gpu_energy_zero(self, mock_run):
+        """Returns None if powermetrics runs but reports 0 GPU energy."""
+        zero_plist = """\
+<plist version="1.0"><dict>
+<key>gpu</key><dict>
+<key>gpu_energy</key><integer>0</integer>
+</dict></dict></plist>"""
+        mock_run.return_value = MagicMock(returncode=0, stdout=zero_plist)
+        monitor = PowerMonitor.__new__(PowerMonitor)
+        monitor._poll_interval = 1.0
+        assert monitor._try_metal_sampler() is None
+
+    @patch("subprocess.run")
+    def test_sampler_callable_invokes_powermetrics(self, mock_run):
+        """The returned sampler calls powermetrics and parses the result."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=self.GOOD_PLIST
+        )
+        monitor = PowerMonitor.__new__(PowerMonitor)
+        monitor._poll_interval = 1.0
+        sampler = monitor._try_metal_sampler()
+        # Reset mock to track the sampler invocation
+        mock_run.reset_mock()
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=self.GOOD_PLIST
+        )
+        watts = sampler()
+        assert watts == pytest.approx(15.0, rel=0.01)
+        mock_run.assert_called_once()


### PR DESCRIPTION
## Summary

- Cherry-picks the powermetrics fix (`9f5f755b`) from `autoresearch/power-sanity` — replaces broken ioreg-based GPU power sampling with `sudo powermetrics --samplers gpu_power`
- **Removes the `AUTORESEARCH_POWERMETRICS_SUDO=1` env var gate** — `sudo -n` (non-interactive mode) already fails safely if passwordless sudo isn't configured, so the env var was unnecessary friction
- Removes dead `_parse_ioreg_gpu_power()` and `_parse_agx_power()` methods that never worked on Apple Silicon
- Adds 11 new tests (plist parsing, auto-detect mocking, edge cases) — **162/162 tests pass**

## Why

The ioreg-based Metal power sampler returned 0.0 on all Apple Silicon chips (M-series). GPU power counters are only accessible via the IOReport C API (requires root) or `sudo powermetrics`. The fix was validated on M5 Max (19.2W under MLX training load) but never merged to main.

## Platform status after this PR

| Platform | Sampler | Status |
|----------|---------|--------|
| CUDA (NVIDIA) | pynvml / nvidia-smi | Working (462–520W on RTX 5090) |
| **Metal/MLX (Apple)** | **powermetrics** | **Fixed** (requires passwordless sudo) |
| ROCm (AMD) | amdsmi / rocm-smi | Untested (Issue #38) |
| HPU (Intel Gaudi) | hl-smi | Untested |

## Prerequisites for Metal power monitoring

```bash
sudo visudo -f /etc/sudoers.d/powermetrics
# Add: %staff ALL=(root) NOPASSWD: /usr/bin/powermetrics
```

If passwordless sudo is not configured, power monitoring silently degrades to (0.0, 0.0) — no crash, no hang.

## Test plan

- [x] All 162 tests pass (11 new for powermetrics parsing + auto-detect)
- [ ] Run a short MLX experiment on M5 Max and confirm non-zero power columns in TSV
- [ ] Verify CUDA path unaffected (existing RTX 5090 data confirms no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)