### PR TITLE
Data: GPT-OSS-120B controlled comparison (n=3, RTX 5070 Ti)

### DIFF
--- a/data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r1.tsv
+++ b/data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r1.tsv
@@ -1,0 +1,101 @@
+exp	description	val_bpb	peak_mem_gb	tok_sec	mfu	steps	status	notes	gpu_name	baseline_sha	watts	joules_per_token	total_energy_joules
+exp0	baseline	1.114404	6.0	0	0.0	0	baseline	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp1	Add label smoothing to cross-entropy loss to improve generalization	1.182425	7.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp2	Add dropout (p=0.1) to attention and MLP residual connections for regularization	1.112874	6.3	0	0.0	0	keep	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp3	Replace linear warmdown with cosine LR schedule and import math for cosine computation	1.247328	6.3	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp4	Add a small learning rate warmup (5% of the time budget) to improve early training stability and final validation bpb	1.286843	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp5	Increase softcap from 12 to 20 to reduce aggressive logit clipping	1.221505	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp6	Make LR warmdown more aggressive by increasing WARMDOWN_RATIO	1.299321	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp7	Enable bias terms in all linear layers of attention and MLP to increase model capacity [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp8	Increase LR warmdown aggressiveness by setting WARMDOWN_RATIO to 0.75	1.296740	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp9	Set Muon weight decay to zero to reduce regularization pressure on matrix parameters	1.263873	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp10	Increase per-layer scalar learning rate to accelerate adaptation of residual scaling parameters	1.360438	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp11	Increase weight decay for token embeddings to improve regularization	1.102690	6.0	0	0.0	0	keep	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp12	Add dropout (p=0.2) after the attention output to improve regularization	1.117295	6.1	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp13	Add dropout (p=0.1) after the MLP projection to improve regularization	1.115899	6.1	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp14	Add dropout after token embedding to regularize embeddings	1.117507	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp15	Increase z-loss regularization coefficient to strengthen logit regularization	1.128981	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp16	Increase softcap from 12 to 20 to reduce logits saturation	1.111371	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp17	Replace squared ReLU activation in MLP with GELU for smoother gradients	1.146046	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp18	Add dropout after token embeddings (p=0.1) to improve regularization combined with existing embedding weight decay [SyntaxError: cannot assign to attribute here. Maybe you meant '==' instead of '='?]	0.000000	0.0	0	0.0	0	crash	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp19	Increase weight decay for token embedding parameters to strengthen regularization	1.133309	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp20	Increase model dimension by raising ASPECT_RATIO from 64 to 80, giving larger capacity without changing depth	1.327238	7.5	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp21	Replace ReLU-square activation in MLP with SiLU (Swish) for smoother gradients	1.135186	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp22	Enable cuDNN benchmark for higher throughput	1.107958	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp23	Increase weight decay for value embedding parameters to improve regularization	1.114988	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp24	FAILED TO APPLY: Enable cuDNN benchmark for higher throughput	0.000000	0.0	0	0.0	0	crash	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp25	Reduce softcap to limit logits magnitude, potentially improving calibration and bpb	1.127834	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp26	Enable TF32 for CUDA matmul and cuDNN to increase throughput	1.107943	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp27	Enable TF32 and cuDNN benchmark for faster matmul and convolution operations	1.112771	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp28	Enable TF32 and cuDNN benchmark for higher throughput	1.154881	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp29	Reduce softcap from 12 to 10 to lessen logits saturation and potentially improve validation bpb	1.110956	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp30	Increase z-loss coefficient to strengthen logit regularization	1.095092	6.0	0	0.0	0	keep	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp31	Reduce softcap from 12 to 8 to limit logits saturation further	1.123904	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp32	Replace linear warmup/warmdown LR schedule with a sinusoidal schedule (0→1→0) to improve learning dynamics	1.152409	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp33	Increase z-loss regularization coefficient from 1e-4 to 5e-4 to strengthen logit regularization	1.095624	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp34	Increase z-loss regularization coefficient from 1e-4 to 1e-3 to strengthen logit regularization	1.100432	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp35	FAILED TO APPLY: Enable TF32 for cuDNN to boost matmul throughput	0.000000	0.0	0	0.0	0	crash	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp36	Introduce a small learning rate warmup (5% of the time budget) to improve early training dynamics	1.122136	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp37	Add a modest LR warmup and increase z-loss regularization to 5e-4 (combining two near‑miss improvements)	1.130629	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp38	Reduce softcap from 12 to 6 to lessen logits saturation	1.116207	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp39	Increase z-loss regularization coefficient slightly to 2e-4 for finer logit regularization	1.137384	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp40	Reduce softcap from 12 to 4 to further limit logits magnitude and improve validation bpb	1.329113	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp41	Enable TF32 for CUDA matmul and cuDNN to increase throughput	1.120853	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp42	Use full attention window for all layers to improve modeling capacity	1.124468	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp43	FAILED TO APPLY: Remove softcap tanh scaling to allow unrestricted logits	0.000000	0.0	0	0.0	0	crash	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp44	Enable TF32 and cuDNN benchmark for higher throughput	1.085303	6.0	0	0.0	0	keep	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp45	Use full attention window for all layers by setting WINDOW_PATTERN to "LLLL"	1.084565	6.0	0	0.0	0	keep	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp46	Replace squared ReLU activation in MLP with standard ReLU to improve gradient flow	1.115150	5.5	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp47	Increase weight decay for value embeddings to improve regularization	1.079505	6.0	0	0.0	0	keep	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp48	Replace linear warmup/warmdown LR schedule with a full cosine decay schedule	1.202778	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp49	Remove logit softcap clipping by setting a very large softcap value, effectively making logits unscaled and improving model expressivity.	1.080280	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp50	Initialize x0_lambdas to zero instead of 0.1 to simplify residual scaling	1.109626	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp51	Increase weight decay for value embeddings to improve regularization	1.080299	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp52	Reduce LR warmdown aggressiveness to keep learning rate high throughout training	1.066211	6.0	0	0.0	0	keep	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp53	Use a constant higher gradient clipping norm (1.0) instead of decreasing schedule	1.066443	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp54	Set a constant higher gradient clipping norm (2.0) instead of the cosine schedule	1.105824	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp55	Replace linear warmup/warmdown LR schedule with a full cosine decay schedule and import math globally	1.238929	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp56	Enable cuDNN benchmark for faster convolution/matmul throughput	1.114144	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp57	Set Muon weight decay to zero to reduce regularization pressure on matrix parameters	1.101565	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp58	Enable cuDNN benchmark for higher throughput, increasing training steps within the time budget	1.099092	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp59	Enable cuDNN benchmark to increase training throughput	1.080865	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp60	Disable adaptive gradient clipping by setting a very large constant clip norm	1.141350	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp61	Eliminate learning rate warmdown to keep LR high throughout training	1.070101	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp62	Disable gradient clipping to reduce overhead and allow larger updates	1.139350	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp63	Set all attention windows to short (half) context to reduce compute per step and increase training throughput	1.080108	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp64	Switch autocast to float16 for faster training throughput	1.080320	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp65	Add dropout after the attention projection to regularize attention output (new regularization not previously tried)	1.089464	6.1	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp66	Enable cuDNN benchmark for higher throughput	1.082889	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp67	Add small weight decay to the x0 scalar parameters to improve regularization	1.078923	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp68	Remove the softcap tanh clipping on logits to allow unrestricted logits	1.081097	6.5	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp69	Increase weight decay for value embedding parameters to strengthen regularization	1.078551	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp70	Increase per-layer scalar learning rate to accelerate adaptation of residual scaling parameters	1.204353	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp71	Use constant weight decay instead of cosine decay schedule	1.074768	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp72	Add small weight decay to x0 scalar parameters for better regularization	1.092799	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp73	Increase z-loss coefficient to 2e-4 for stronger logit regularization	1.085667	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp74	Use short attention windows for all intermediate layers to reduce compute and increase training steps	1.080254	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp75	Enable cuDNN benchmark and TF32 for faster matmul, increasing training throughput	1.080878	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp76	Enable cuDNN benchmark and TF32 for faster matmul, increasing training throughput	1.083738	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp77	Change loss reduction from mean to sum to increase gradient signal per token [GPU: NVIDIA GeForce RTX 5070 Ti (16303MB VRAM)	0.000000	0.0	0	0.0	0	crash	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp78	Switch autocast to float16 for faster matmul on RTX 5070 Ti	1.083653	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp79	Increase softcap from 12 to 24 to allow larger logit range without removing tanh scaling	1.079418	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp80	Increase weight decay for per-layer residual scaling parameters (resid_lambdas) to improve regularization	1.089523	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp81	Enable cuDNN benchmark for higher throughput	1.412748	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp82	Compile model with reduced overhead mode to increase training throughput [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp83	Enable reduce-overhead mode for torch.compile to improve training throughput [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp84	Reduce z-loss regularization coefficient from 1e-4 to 5e-5 to lessen logit regularization pressure	1.415651	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp85	Enable cuDNN benchmark and TF32 for faster matmul and convolution, increasing training throughput	1.453981	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp86	Eliminate LR warmdown and use a constant higher gradient clipping norm (1.0) to keep learning rate high and reduce clipping variability	1.335407	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp87	Use all short attention windows to increase training throughput	1.374112	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp88	Enable cuDNN benchmark and TF32 for higher throughput	1.386249	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp89	Set Muon optimizer momentum to a constant high value (0.95) instead of a cosine warmup schedule	1.448581	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp90	Switch mixed precision from bfloat16 to float16 for higher throughput	2.365822	6.5	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp91	Enable cuDNN benchmark for higher throughput	1.422519	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp92	Use constant high momentum (0.95) for Muon optimizer instead of cosine warmup schedule	1.431548	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp93	Untie the language model head from the token embedding matrix to give the output layer its own parameters	1.316083	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp94	Disable autocast to reduce overhead by using model's native bfloat16 weights directly [^^^^^^^^^^^^^^^^^	0.000000	0.0	0	0.0	0	crash	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp95	Switch model to float16 precision for faster throughput	2.369970	6.5	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp96	Enable TF32 for CUDA matmul and cuDNN to increase throughput	1.310746	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp97	Increase weight decay for per-layer scalar parameters (resid_lambdas) to improve regularization	1.192487	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp98	Increase Muon optimizer orthogonalization steps from 5 to 7 (ns_steps) to improve gradient quality	1.219694	6.0	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp99	Add dropout to value embeddings to regularize the ResFormer pathway	1.165382	6.1	0	0.0	0	discard	gptoss120b-r1-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0

--- a/data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r2.tsv
+++ b/data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r2.tsv
@@ -1,0 +1,101 @@
+exp	description	val_bpb	peak_mem_gb	tok_sec	mfu	steps	status	notes	gpu_name	baseline_sha	watts	joules_per_token	total_energy_joules
+exp0	baseline	1.202751	6.0	0	0.0	0	baseline	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp1	Add label smoothing to cross-entropy loss to improve generalization	1.179595	7.0	0	0.0	0	keep	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp2	Add dropout (p=0.1) after attention and MLP residual connections to improve regularization	1.223943	7.2	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp3	Reduce embedding initialization std from 1.0 to 0.02 for better generalization	1.064721	6.0	0	0.0	0	keep	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp4	Add small L2 regularization on token embeddings to improve generalization [IndentationError: unexpected indent]	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp5	Set matrix weight decay to zero to reduce regularization on core weights	1.119637	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp6	Add a small learning rate warmup to improve early training stability	1.126646	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp7	Add a small learning rate warmup (5% of the time budget) to improve early training stability	1.126164	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp8	Reduce softcap from 12 to 6 to better regularize logits	1.129564	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp9	Increase L2 regularization on token embeddings to improve generalization	1.086838	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp10	Increase L2 regularization (weight decay) on token embeddings to improve generalization	1.086493	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp11	Add bias terms to all linear layers (except ve_gate) to increase model capacity [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp12	Add dropout after token embeddings to improve regularization	1.089443	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp13	Add dropout after final layer normalization before logits to improve regularization	1.071234	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp14	Replace ReLU-square activation in MLP with GELU for better expressivity	1.109126	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp15	Increase z-loss regularization coefficient to strengthen logit regularization	1.089720	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp16	Enable cuDNN benchmark to improve throughput and allow more training steps within the time budget	1.083413	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp17	Enable cuDNN benchmark for higher throughput	1.087206	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp18	Increase weight decay for token embeddings to improve regularization	1.077753	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp19	FAILED TO APPLY: Add dropout after final layer normalization before logits to improve regularization	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp20	Reduce softcap from 12 to 8 to improve logit regularization and potentially lower val_bpb	1.093030	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp21	Replace ReLU-square activation in MLP with SiLU (Swish) for potentially better expressivity	1.112338	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp22	Replace linear LR schedule with cosine schedule for smoother learning rate decay [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp23	Use torch.compile's reduce-overhead mode to improve training throughput [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp24	FAILED TO APPLY: Add dropout after token embeddings and after final layer normalization to improve regularization	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp25	Add dropout after attention output to improve regularization	1.093541	6.1	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp26	Add a small learning rate warmup (5% of time budget) to improve early training stability	1.136945	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp27	Increase Muon optimizer orthogonalization steps from 5 to 7 for potentially better convergence	1.083804	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp28	FAILED TO APPLY: Enable cuDNN benchmark for potentially higher throughput	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp29	FAILED TO APPLY: Increase learning rate for per-layer scalar parameters to accelerate adaptation	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp30	Increase Muon optimizer orthogonalization steps from 5 to 9 for potentially better convergence	1.084079	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp31	Increase Muon optimizer orthogonalization steps from 5 to 11 for potentially better convergence	1.087894	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp32	FAILED TO APPLY: Use higher Adam betas for better stability and convergence	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp33	Add dropout after final layer normalization before logits (p=0.1) to improve regularization	1.075131	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp34	Remove adaptive gradient clipping by setting max_norm to a constant high value	1.084362	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp35	Replace linear warmdown with cosine LR decay for smoother schedule	1.209291	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp36	Add a small learning rate warmup (2% of the time budget) to improve early training stability	1.120436	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp37	Set a non-zero final learning rate fraction to retain some learning rate at the end of training	1.073404	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp38	Use cosine decay for learning rate warmdown and import math at top	1.144734	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp39	Replace linear LR schedule with cosine warmup and warmdown for smoother learning rate progression	1.090000	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp40	FAILED TO APPLY: Enable cuDNN benchmark for higher throughput	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp41	Set Muon optimizer weight decay to zero to reduce regularization on core matrix parameters	1.106942	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp42	Disable adaptive gradient clipping by setting a very high max_norm	1.140760	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp43	Use all short windows to reduce attention compute and increase training throughput	1.083153	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp44	Disable adaptive gradient clipping by setting a very high max_norm	1.145432	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp45	FAILED TO APPLY: Enable cuDNN benchmark for higher throughput	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp46	Enable cuDNN benchmark for higher throughput	1.086650	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp47	FAILED TO APPLY: Combine final-layer dropout with a non-zero final learning rate fraction to improve regularization and maintain learning rate at the end	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp48	Increase z-loss regularization coefficient from 1e-4 to 2e-4 to strengthen logit regularization	1.091623	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp49	Set a small non-zero final learning rate fraction to keep learning rate at the end of training	1.079878	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp50	Disable adaptive gradient clipping by using a constant max_norm of 1.0	1.082911	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp51	Increase z-loss regularization coefficient to strengthen logit regularization	1.089140	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp52	Increase Muon orthogonalization steps from 5 to 7 for potentially better convergence	1.083364	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp53	Enable torch.compile reduce-overhead mode to improve training throughput [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp54	Increase z-loss regularization coefficient to strengthen logit regularization	1.091472	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp55	Use all short windows ("SSSS") to reduce compute per step and increase training throughput	1.085726	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp56	Enable cuDNN benchmark to increase training throughput	1.082595	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp57	FAILED TO APPLY: Enable cuDNN benchmark for higher throughput	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp58	Add stochastic depth (randomly drop entire transformer blocks) to improve regularization and potentially lower val_bpb.	1.335104	11.6	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp59	Increase softcap from 12 to 24 to allow larger logits range, potentially improving model expressivity and lowering val_bpb	1.082677	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp60	Reduce token embedding initialization std to 0.02 for better generalization	1.058682	6.0	0	0.0	0	keep	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp61	Enable cuDNN benchmark for higher throughput	1.061450	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp62	Use full float32 precision for matmul instead of high (TF32) to improve training stability and potentially lower validation bpb.	1.084675	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp63	Reduce softcap from 12 to 8 to allow logits more expressive range	1.092761	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp64	Increase model depth to at least 14 layers to improve capacity	2.822764	17.1	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp65	Add dropout (p=0.2) after final layer normalization before logits to improve regularization	1.132095	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp66	Increase per-layer scalar learning rates by doubling SCALAR_LR	1.206528	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp67	Enable cuDNN benchmark and disable TF32 for potentially higher throughput and better precision	1.085946	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp68	FAILED TO APPLY: Add a modest dropout (p=0.05) after the final layer normalization before logits to improve regularization	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp69	Disable gradient clipping to increase training throughput	1.149303	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp70	Increase softcap from 12 to 16 to allow larger logit range and potentially improve model expressivity	1.088320	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp71	Lower float32 matmul precision to medium for faster training throughput	1.082765	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp72	Use constant weight decay instead of cosine decay schedule for Muon optimizer	1.080724	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp73	Increase final learning rate fraction to retain more LR at end of training	1.062803	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp74	Add a modest dropout (p=0.1) after each transformer block's output to improve regularization	1.098751	6.1	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp75	Switch autocast to float16 for potentially higher throughput	1.084892	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp76	Increase z-loss regularization coefficient from 1e-4 to 5e-4 for stronger logit regularization	1.090477	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp77	Increase head dimension to reduce number of attention heads	1.062834	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp78	Disable aggressive gradient clipping by using a large constant max_norm	1.143079	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp79	Enable cuDNN benchmark and disable TF32 for higher precision and potential throughput gains	1.085846	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp80	Disable TF32 matrix multiplication for higher precision (may improve validation bpb)	1.084867	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp81	Enable cuDNN benchmark to increase training throughput	1.085483	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp82	Disable adaptive gradient clipping to reduce overhead and allow larger gradients	1.142858	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp83	Keep token and value embeddings in float32 (higher precision) instead of casting to bf16, which may improve validation bpb	1.100048	7.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp84	FAILED TO APPLY: Use higher Adam betas for better stability and convergence	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp85	Reduce HEAD_DIM to increase number of attention heads (more expressive attention)	1.168823	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp86	FAILED TO APPLY: Enable cuDNN benchmark for higher training throughput	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp87	Add bias term to the language model head to increase expressivity	1.096577	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp88	Reduce HEAD_DIM to increase number of attention heads (more expressive attention)	1.171037	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp89	Reduce float32 matmul precision from high to medium to increase training throughput	1.096999	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp90	Reduce token embedding initialization std from 1.0 to 0.01 (lower than previous 0.02) to improve generalization	1.063359	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp91	Reduce Muon optimizer weight decay from 0.2 to 0.05 to improve regularization and potentially lower val_bpb	1.110836	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp92	Reduce LR warmdown ratio to keep higher learning rate longer during training	1.073310	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp93	Disable adaptive gradient clipping by setting a large constant max_norm	1.158634	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp94	Remove softcap tanh scaling from logits to allow unrestricted logits range	1.093284	6.5	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp95	Reduce softcap from 12 to 10 to allow slightly larger logit range and potentially improve validation bpb	1.096605	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp96	Reduce LR warmdown fraction to keep learning rate higher longer, potentially improving convergence within the fixed time budget	1.072476	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp97	Increase weight decay for token and value embedding parameters to improve regularization	1.086375	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp98	Increase weight decay for token embedding parameters to improve regularization	1.085449	6.0	0	0.0	0	discard	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp99	Keep token and value embeddings in float32 instead of casting to bfloat16 to improve model quality [IndentationError: expected an indented block after 'for' statement on line 202]	0.000000	0.0	0	0.0	0	crash	gptoss120b-r2-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0

--- a/data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r3.tsv
+++ b/data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r3.tsv
@@ -1,0 +1,101 @@
+exp	description	val_bpb	peak_mem_gb	tok_sec	mfu	steps	status	notes	gpu_name	baseline_sha	watts	joules_per_token	total_energy_joules
+exp0	baseline	1.085763	6.0	0	0.0	0	baseline	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp1	Add a small learning rate warmup phase to improve early training stability	1.113011	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp2	Add dropout (p=0.1) after MLP activation to regularize training	1.092556	6.5	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp3	Add label smoothing (0.01) to cross-entropy loss for better generalization	1.109973	7.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp4	Increase weight decay on token embeddings and value embeddings to improve regularization	1.078353	6.0	0	0.0	0	keep	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp5	FAILED TO APPLY: Add dropout (p=0.1) after each residual addition in Block to improve regularization	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp6	Add small L2 regularization on per-layer scalar parameters (resid_lambdas and x0_lambdas) to improve stability and reduce validation bpb	1.091502	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp7	Replace linear LR schedule with a cosine annealing schedule to improve learning dynamics [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp8	Add small gradient noise injection after clipping to improve generalization [timeout (900s wall clock)]	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp9	Increase z-loss regularization strength to better control logits magnitude	1.090483	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp10	Switch LR schedule to cosine decay (with optional warmup) for smoother learning rate progression	1.210657	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp11	Increase z-loss regularization strength to better control logits magnitude	1.086794	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp12	Add a small learning rate warmup to improve early training stability	1.112757	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp13	Increase weight decay for token embeddings to improve regularization	1.077110	6.0	0	0.0	0	keep	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp14	Add modest label smoothing (0.05) to cross-entropy loss for better generalization	1.216479	7.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp15	Replace custom ReLU-square activation in MLP with GELU for potentially smoother gradients	1.104767	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp16	Add dropout after attention output to regularize and improve validation bpb	1.090329	6.1	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp17	Add embedding dropout (p=0.1) to regularize token embeddings	1.083499	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp18	Increase softcap to allow larger logits, potentially improving validation bpb	1.082536	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp19	Increase model capacity by raising ASPECT_RATIO from 64 to 80, yielding larger hidden dimension and more attention heads	1.282743	7.5	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp20	Increase softcap from 12 to 20 to allow larger logits, potentially improving validation bpb	1.085502	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp21	Add dropout to value embeddings after gating to regularize attention input	1.090093	6.1	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp22	Increase softcap from 12 to 30 to allow larger logits and potentially improve validation bpb	1.086789	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp23	Set a non-zero final learning rate fraction to retain some learning rate at the end of training	1.076773	6.0	0	0.0	0	keep	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp24	Make LR warmdown more aggressive to potentially improve validation bpb	1.096443	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp25	Increase z-loss regularization weight to better control logits magnitude	1.088880	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp26	Set matrix weight decay to zero to reduce over-regularization of Muon parameters	1.110470	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp27	Add bias to the query projection linear layer to improve expressivity [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp28	Use full context window at all layers by changing window pattern to all long windows	1.086437	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp29	Increase softcap from 12 to 15 to allow slightly larger logits	1.084003	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp30	Increase z-loss regularization weight to strengthen logit magnitude control	1.092663	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp31	Lower softcap from 12 to 8 to potentially improve logit scaling and validation bpb	1.096128	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp32	Increase weight decay for token embeddings to 0.01 for stronger regularization	1.076852	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp33	Reduce head dimension to increase training throughput and allow more steps within the time budget	1.153519	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp34	Increase weight decay for value embeddings from 0.001 to 0.01 for stronger regularization	1.082378	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp35	Reduce model size by decreasing ASPECT_RATIO to increase training throughput	0.992396	4.6	0	0.0	0	keep	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp36	Increase z-loss regularization weight to strengthen logit magnitude control	0.998766	4.6	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp37	Increase z-loss regularization weight to strengthen logit magnitude control	1.088001	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp38	Initialize per-layer x0 scaling parameters to zero instead of 0.1 to reduce initial bias and potentially improve training dynamics	1.107297	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp39	Reduce value embedding gate scaling from 2× to 1× to lessen residual impact of value embeddings	1.094731	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp40	Set Muon weight decay to zero to reduce regularization on matrix parameters	1.109384	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp41	Introduce a small learning rate warmup phase (2% of total time) to improve early training stability	1.116748	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp42	Increase HEAD_DIM to 256 to reduce number of attention heads and improve training throughput	1.061178	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp43	Increase z-loss regularization coefficient to strengthen logit magnitude control	1.092418	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp44	Set Muon weight decay to zero to reduce over-regularization	1.107320	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp45	FAILED TO APPLY: Set a non-zero final learning rate fraction to keep some learning rate at the end of training	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp46	Increase z-loss regularization weight to strengthen logit magnitude control	1.087672	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp47	Add mild label smoothing (0.02) to cross-entropy loss for better generalization	1.138675	7.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp48	Increase z-loss regularization weight from 1e-4 to 5e-4 to strengthen logit magnitude control	1.088482	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp49	Add small weight decay to x0 scaling parameters for better regularization	1.084159	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp50	Enable TF32 and cuDNN benchmarking to increase training throughput	1.083608	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp51	Initialize per-layer residual scaling to 0.5 and remove initial x0 bias to improve training dynamics	1.066255	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp52	Enable cuDNN benchmark for faster kernel selection, increasing training throughput	1.086526	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp53	Reduce value‑embedding gate scaling from 2× to 1× (remove extra factor) to lessen residual impact of value embeddings	1.095000	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp54	Enable cuDNN benchmark and TF32 for higher training throughput	1.083986	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp55	Switch autocast precision from bfloat16 to float16 for faster throughput	1.087125	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp56	Add small L2 weight decay to per-layer x0 scaling parameters for better regularization	1.080953	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp57	Reduce z-loss regularization weight to lessen logit magnitude penalty	1.081734	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp58	Reduce the weight decay floor in the cosine decay schedule to allow higher learning rates later in training	1.087108	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp59	Add dropout (p=0.2) after attention and MLP outputs in each Block for regularization	1.078586	6.3	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp60	Increase weight decay for embedding-related AdamW parameter groups from 0.001 to 0.01 to strengthen regularization	1.077778	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp61	Increase scalar learning rate to allow faster adaptation of per-layer scaling parameters	1.129527	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp62	Add small weight decay to x0 scaling parameters for better regularization	1.085324	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp63	Increase weight decay for value embedding parameters to 0.01 for better regularization	1.084072	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp64	Reduce z-loss regularization weight to lessen logit magnitude penalty	1.083171	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp65	FAILED TO APPLY: Add small label smoothing (0.001) to cross-entropy loss	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp66	Increase Muon weight decay to strengthen regularization	1.079083	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp67	Increase LR warmdown ratio to decay learning rate more aggressively towards the end	1.120822	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp68	Remove Muon weight decay to reduce regularization on matrix parameters	1.106532	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp69	Enable cuDNN benchmark and TF32 matmul for higher throughput	1.087170	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp70	Increase LR warmdown aggressiveness to 0.75 to improve convergence	1.121343	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp71	Use all short windows to reduce attention compute and increase training steps	1.088194	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp72	Initialize residual scaling parameters to 0.5 instead of 1.0 to improve training dynamics	1.069875	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp73	FAILED TO APPLY: Add a tiny label smoothing (0.001) to cross-entropy loss for better regularization	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp74	Force use of native torch SDPA instead of flash-attn3 to improve throughput	1.084256	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp75	Replace ReLU-square activation in MLP with SiLU (Swish) activation	1.106846	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp76	Make softcap a learnable parameter instead of a fixed constant [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp77	Use torch.compile with reduce-overhead mode to lower compilation overhead and increase training throughput [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp78	Add tiny label smoothing (0.001) to cross-entropy loss for slight regularization	1.094065	7.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp79	Increase weight decay for token embeddings, value embeddings, and lm_head to 0.01 for stronger regularization	1.076748	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp80	FAILED TO APPLY: Enable cuDNN benchmark and TF32 for higher training throughput	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp81	Replace piecewise LR schedule with a smooth cosine decay over the entire training time	1.206338	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp82	Reduce model dimension by lowering ASPECT_RATIO to 48, increasing training steps within the time budget	0.991808	4.6	0	0.0	0	keep	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp83	Enable reduce-overhead mode in torch.compile to lower compile overhead and increase effective training steps [Traceback (most recent call last):	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp84	Increase head dimension to reduce number of attention heads and improve throughput	1.413419	9.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp85	Replace piecewise LR schedule with a smooth cosine annealing schedule for the entire training	1.211807	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp86	Reduce model dimension by lowering ASPECT_RATIO from 64 to 48, enabling more training steps within the time budget	0.993419	4.6	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp87	Reduce weight initialization scale to improve early training stability	1.076733	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp88	Switch autocast precision from bfloat16 to float16 for faster throughput	1.082897	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp89	Increase softcap from 12 to 40 to allow larger logits and potentially improve validation bpb	1.083666	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp90	Increase scalar learning rate to accelerate per-layer scaling parameter updates	1.211362	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp91	Increase head dimension to 256, reducing number of attention heads and improving throughput	1.062020	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp92	Remove weight decay floor in cosine schedule to allow decay to zero at end of training	1.088426	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp93	Disable aggressive adaptive gradient clipping by setting a constant high clipping norm	1.082817	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp94	Enable TF32 and cuDNN benchmark to increase training throughput	1.082073	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp95	Remove weight decay floor in cosine decay schedule to allow weight decay to reach zero at training end	1.086932	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp96	Enable cuDNN benchmark and TF32 for faster training throughput	1.085340	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp97	Reduce value embedding gate scaling from 2× to 1× to lessen its impact on attention values	1.098193	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp98	FAILED TO APPLY: Increase per-layer scalar learning rates by doubling SCALAR_LR	0.000000	0.0	0	0.0	0	crash	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0
+exp99	Increase HEAD_DIM to 512 to reduce number of attention heads and improve training throughput	1.362862	6.0	0	0.0	0	discard	gptoss120b-r3-controlled	NVIDIA GeForce RTX 5070 Ti	3fb6704	0.0	0.000000	0.0

--- a/docs/benchmark/data.json
+++ b/docs/benchmark/data.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-04-04T15:32:10.562737+00:00",
-  "total_runs": 20,
+  "generated_at": "2026-04-05T15:22:23.135870+00:00",
+  "total_runs": 23,
   "filters": {
     "datasets": [
       "climbmix",
@@ -9306,6 +9306,1672 @@
     },
     {
       "dataset": "pubmed",
+      "model": "GPT-OSS-120B",
+      "model_slug": "gptoss120b",
+      "model_family": "OpenAI",
+      "gpu_name": "NVIDIA GeForce RTX 5070 Ti",
+      "gpu_slug": "rtx5070ti",
+      "contributor": "bmdhodl",
+      "runs": 3,
+      "provisional": false,
+      "keep_rate_mean": 5.1,
+      "keep_rate_sd": 2.0,
+      "crash_rate_mean": 13.1,
+      "crash_rate_sd": 4.6,
+      "best_bpb": 0.991808,
+      "total_exps_sum": 297,
+      "total_keeps_sum": 15,
+      "total_crashes_sum": 39,
+      "run_details": [
+        {
+          "file": "data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r1.tsv",
+          "dataset": "pubmed",
+          "model_slug": "gptoss120b",
+          "model": "GPT-OSS-120B",
+          "model_family": "OpenAI",
+          "contributor": "bmdhodl",
+          "gpu_slug": "rtx5070ti",
+          "gpu_name": "NVIDIA GeForce RTX 5070 Ti",
+          "total_exps": 99,
+          "keeps": 7,
+          "crashes": 9,
+          "discards": 83,
+          "skips": 0,
+          "keep_rate": 7.07070707070707,
+          "crash_rate": 9.090909090909092,
+          "best_bpb": 1.066211,
+          "baseline_bpb": 1.114404,
+          "bpb_trajectory": [
+            {
+              "exp": "exp0",
+              "val_bpb": 1.114404,
+              "status": "baseline"
+            },
+            {
+              "exp": "exp1",
+              "val_bpb": 1.182425,
+              "status": "discard"
+            },
+            {
+              "exp": "exp2",
+              "val_bpb": 1.112874,
+              "status": "keep"
+            },
+            {
+              "exp": "exp3",
+              "val_bpb": 1.247328,
+              "status": "discard"
+            },
+            {
+              "exp": "exp4",
+              "val_bpb": 1.286843,
+              "status": "discard"
+            },
+            {
+              "exp": "exp5",
+              "val_bpb": 1.221505,
+              "status": "discard"
+            },
+            {
+              "exp": "exp6",
+              "val_bpb": 1.299321,
+              "status": "discard"
+            },
+            {
+              "exp": "exp7",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp8",
+              "val_bpb": 1.29674,
+              "status": "discard"
+            },
+            {
+              "exp": "exp9",
+              "val_bpb": 1.263873,
+              "status": "discard"
+            },
+            {
+              "exp": "exp10",
+              "val_bpb": 1.360438,
+              "status": "discard"
+            },
+            {
+              "exp": "exp11",
+              "val_bpb": 1.10269,
+              "status": "keep"
+            },
+            {
+              "exp": "exp12",
+              "val_bpb": 1.117295,
+              "status": "discard"
+            },
+            {
+              "exp": "exp13",
+              "val_bpb": 1.115899,
+              "status": "discard"
+            },
+            {
+              "exp": "exp14",
+              "val_bpb": 1.117507,
+              "status": "discard"
+            },
+            {
+              "exp": "exp15",
+              "val_bpb": 1.128981,
+              "status": "discard"
+            },
+            {
+              "exp": "exp16",
+              "val_bpb": 1.111371,
+              "status": "discard"
+            },
+            {
+              "exp": "exp17",
+              "val_bpb": 1.146046,
+              "status": "discard"
+            },
+            {
+              "exp": "exp18",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp19",
+              "val_bpb": 1.133309,
+              "status": "discard"
+            },
+            {
+              "exp": "exp20",
+              "val_bpb": 1.327238,
+              "status": "discard"
+            },
+            {
+              "exp": "exp21",
+              "val_bpb": 1.135186,
+              "status": "discard"
+            },
+            {
+              "exp": "exp22",
+              "val_bpb": 1.107958,
+              "status": "discard"
+            },
+            {
+              "exp": "exp23",
+              "val_bpb": 1.114988,
+              "status": "discard"
+            },
+            {
+              "exp": "exp24",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp25",
+              "val_bpb": 1.127834,
+              "status": "discard"
+            },
+            {
+              "exp": "exp26",
+              "val_bpb": 1.107943,
+              "status": "discard"
+            },
+            {
+              "exp": "exp27",
+              "val_bpb": 1.112771,
+              "status": "discard"
+            },
+            {
+              "exp": "exp28",
+              "val_bpb": 1.154881,
+              "status": "discard"
+            },
+            {
+              "exp": "exp29",
+              "val_bpb": 1.110956,
+              "status": "discard"
+            },
+            {
+              "exp": "exp30",
+              "val_bpb": 1.095092,
+              "status": "keep"
+            },
+            {
+              "exp": "exp31",
+              "val_bpb": 1.123904,
+              "status": "discard"
+            },
+            {
+              "exp": "exp32",
+              "val_bpb": 1.152409,
+              "status": "discard"
+            },
+            {
+              "exp": "exp33",
+              "val_bpb": 1.095624,
+              "status": "discard"
+            },
+            {
+              "exp": "exp34",
+              "val_bpb": 1.100432,
+              "status": "discard"
+            },
+            {
+              "exp": "exp35",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp36",
+              "val_bpb": 1.122136,
+              "status": "discard"
+            },
+            {
+              "exp": "exp37",
+              "val_bpb": 1.130629,
+              "status": "discard"
+            },
+            {
+              "exp": "exp38",
+              "val_bpb": 1.116207,
+              "status": "discard"
+            },
+            {
+              "exp": "exp39",
+              "val_bpb": 1.137384,
+              "status": "discard"
+            },
+            {
+              "exp": "exp40",
+              "val_bpb": 1.329113,
+              "status": "discard"
+            },
+            {
+              "exp": "exp41",
+              "val_bpb": 1.120853,
+              "status": "discard"
+            },
+            {
+              "exp": "exp42",
+              "val_bpb": 1.124468,
+              "status": "discard"
+            },
+            {
+              "exp": "exp43",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp44",
+              "val_bpb": 1.085303,
+              "status": "keep"
+            },
+            {
+              "exp": "exp45",
+              "val_bpb": 1.084565,
+              "status": "keep"
+            },
+            {
+              "exp": "exp46",
+              "val_bpb": 1.11515,
+              "status": "discard"
+            },
+            {
+              "exp": "exp47",
+              "val_bpb": 1.079505,
+              "status": "keep"
+            },
+            {
+              "exp": "exp48",
+              "val_bpb": 1.202778,
+              "status": "discard"
+            },
+            {
+              "exp": "exp49",
+              "val_bpb": 1.08028,
+              "status": "discard"
+            },
+            {
+              "exp": "exp50",
+              "val_bpb": 1.109626,
+              "status": "discard"
+            },
+            {
+              "exp": "exp51",
+              "val_bpb": 1.080299,
+              "status": "discard"
+            },
+            {
+              "exp": "exp52",
+              "val_bpb": 1.066211,
+              "status": "keep"
+            },
+            {
+              "exp": "exp53",
+              "val_bpb": 1.066443,
+              "status": "discard"
+            },
+            {
+              "exp": "exp54",
+              "val_bpb": 1.105824,
+              "status": "discard"
+            },
+            {
+              "exp": "exp55",
+              "val_bpb": 1.238929,
+              "status": "discard"
+            },
+            {
+              "exp": "exp56",
+              "val_bpb": 1.114144,
+              "status": "discard"
+            },
+            {
+              "exp": "exp57",
+              "val_bpb": 1.101565,
+              "status": "discard"
+            },
+            {
+              "exp": "exp58",
+              "val_bpb": 1.099092,
+              "status": "discard"
+            },
+            {
+              "exp": "exp59",
+              "val_bpb": 1.080865,
+              "status": "discard"
+            },
+            {
+              "exp": "exp60",
+              "val_bpb": 1.14135,
+              "status": "discard"
+            },
+            {
+              "exp": "exp61",
+              "val_bpb": 1.070101,
+              "status": "discard"
+            },
+            {
+              "exp": "exp62",
+              "val_bpb": 1.13935,
+              "status": "discard"
+            },
+            {
+              "exp": "exp63",
+              "val_bpb": 1.080108,
+              "status": "discard"
+            },
+            {
+              "exp": "exp64",
+              "val_bpb": 1.08032,
+              "status": "discard"
+            },
+            {
+              "exp": "exp65",
+              "val_bpb": 1.089464,
+              "status": "discard"
+            },
+            {
+              "exp": "exp66",
+              "val_bpb": 1.082889,
+              "status": "discard"
+            },
+            {
+              "exp": "exp67",
+              "val_bpb": 1.078923,
+              "status": "discard"
+            },
+            {
+              "exp": "exp68",
+              "val_bpb": 1.081097,
+              "status": "discard"
+            },
+            {
+              "exp": "exp69",
+              "val_bpb": 1.078551,
+              "status": "discard"
+            },
+            {
+              "exp": "exp70",
+              "val_bpb": 1.204353,
+              "status": "discard"
+            },
+            {
+              "exp": "exp71",
+              "val_bpb": 1.074768,
+              "status": "discard"
+            },
+            {
+              "exp": "exp72",
+              "val_bpb": 1.092799,
+              "status": "discard"
+            },
+            {
+              "exp": "exp73",
+              "val_bpb": 1.085667,
+              "status": "discard"
+            },
+            {
+              "exp": "exp74",
+              "val_bpb": 1.080254,
+              "status": "discard"
+            },
+            {
+              "exp": "exp75",
+              "val_bpb": 1.080878,
+              "status": "discard"
+            },
+            {
+              "exp": "exp76",
+              "val_bpb": 1.083738,
+              "status": "discard"
+            },
+            {
+              "exp": "exp77",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp78",
+              "val_bpb": 1.083653,
+              "status": "discard"
+            },
+            {
+              "exp": "exp79",
+              "val_bpb": 1.079418,
+              "status": "discard"
+            },
+            {
+              "exp": "exp80",
+              "val_bpb": 1.089523,
+              "status": "discard"
+            },
+            {
+              "exp": "exp81",
+              "val_bpb": 1.412748,
+              "status": "discard"
+            },
+            {
+              "exp": "exp82",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp83",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp84",
+              "val_bpb": 1.415651,
+              "status": "discard"
+            },
+            {
+              "exp": "exp85",
+              "val_bpb": 1.453981,
+              "status": "discard"
+            },
+            {
+              "exp": "exp86",
+              "val_bpb": 1.335407,
+              "status": "discard"
+            },
+            {
+              "exp": "exp87",
+              "val_bpb": 1.374112,
+              "status": "discard"
+            },
+            {
+              "exp": "exp88",
+              "val_bpb": 1.386249,
+              "status": "discard"
+            },
+            {
+              "exp": "exp89",
+              "val_bpb": 1.448581,
+              "status": "discard"
+            },
+            {
+              "exp": "exp90",
+              "val_bpb": 2.365822,
+              "status": "discard"
+            },
+            {
+              "exp": "exp91",
+              "val_bpb": 1.422519,
+              "status": "discard"
+            },
+            {
+              "exp": "exp92",
+              "val_bpb": 1.431548,
+              "status": "discard"
+            },
+            {
+              "exp": "exp93",
+              "val_bpb": 1.316083,
+              "status": "discard"
+            },
+            {
+              "exp": "exp94",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp95",
+              "val_bpb": 2.36997,
+              "status": "discard"
+            },
+            {
+              "exp": "exp96",
+              "val_bpb": 1.310746,
+              "status": "discard"
+            },
+            {
+              "exp": "exp97",
+              "val_bpb": 1.192487,
+              "status": "discard"
+            },
+            {
+              "exp": "exp98",
+              "val_bpb": 1.219694,
+              "status": "discard"
+            },
+            {
+              "exp": "exp99",
+              "val_bpb": 1.165382,
+              "status": "discard"
+            }
+          ],
+          "kept_improvements": [
+            {
+              "exp": "exp2",
+              "val_bpb": 1.112874,
+              "description": "Add dropout (p=0.1) to attention and MLP residual connections for regularization"
+            },
+            {
+              "exp": "exp11",
+              "val_bpb": 1.10269,
+              "description": "Increase weight decay for token embeddings to improve regularization"
+            },
+            {
+              "exp": "exp30",
+              "val_bpb": 1.095092,
+              "description": "Increase z-loss coefficient to strengthen logit regularization"
+            },
+            {
+              "exp": "exp44",
+              "val_bpb": 1.085303,
+              "description": "Enable TF32 and cuDNN benchmark for higher throughput"
+            },
+            {
+              "exp": "exp45",
+              "val_bpb": 1.084565,
+              "description": "Use full attention window for all layers by setting WINDOW_PATTERN to \"LLLL\""
+            },
+            {
+              "exp": "exp47",
+              "val_bpb": 1.079505,
+              "description": "Increase weight decay for value embeddings to improve regularization"
+            },
+            {
+              "exp": "exp52",
+              "val_bpb": 1.066211,
+              "description": "Reduce LR warmdown aggressiveness to keep learning rate high throughout training"
+            }
+          ]
+        },
+        {
+          "file": "data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r2.tsv",
+          "dataset": "pubmed",
+          "model_slug": "gptoss120b",
+          "model": "GPT-OSS-120B",
+          "model_family": "OpenAI",
+          "contributor": "bmdhodl",
+          "gpu_slug": "rtx5070ti",
+          "gpu_name": "NVIDIA GeForce RTX 5070 Ti",
+          "total_exps": 99,
+          "keeps": 3,
+          "crashes": 18,
+          "discards": 78,
+          "skips": 0,
+          "keep_rate": 3.0303030303030303,
+          "crash_rate": 18.181818181818183,
+          "best_bpb": 1.058682,
+          "baseline_bpb": 1.202751,
+          "bpb_trajectory": [
+            {
+              "exp": "exp0",
+              "val_bpb": 1.202751,
+              "status": "baseline"
+            },
+            {
+              "exp": "exp1",
+              "val_bpb": 1.179595,
+              "status": "keep"
+            },
+            {
+              "exp": "exp2",
+              "val_bpb": 1.223943,
+              "status": "discard"
+            },
+            {
+              "exp": "exp3",
+              "val_bpb": 1.064721,
+              "status": "keep"
+            },
+            {
+              "exp": "exp4",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp5",
+              "val_bpb": 1.119637,
+              "status": "discard"
+            },
+            {
+              "exp": "exp6",
+              "val_bpb": 1.126646,
+              "status": "discard"
+            },
+            {
+              "exp": "exp7",
+              "val_bpb": 1.126164,
+              "status": "discard"
+            },
+            {
+              "exp": "exp8",
+              "val_bpb": 1.129564,
+              "status": "discard"
+            },
+            {
+              "exp": "exp9",
+              "val_bpb": 1.086838,
+              "status": "discard"
+            },
+            {
+              "exp": "exp10",
+              "val_bpb": 1.086493,
+              "status": "discard"
+            },
+            {
+              "exp": "exp11",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp12",
+              "val_bpb": 1.089443,
+              "status": "discard"
+            },
+            {
+              "exp": "exp13",
+              "val_bpb": 1.071234,
+              "status": "discard"
+            },
+            {
+              "exp": "exp14",
+              "val_bpb": 1.109126,
+              "status": "discard"
+            },
+            {
+              "exp": "exp15",
+              "val_bpb": 1.08972,
+              "status": "discard"
+            },
+            {
+              "exp": "exp16",
+              "val_bpb": 1.083413,
+              "status": "discard"
+            },
+            {
+              "exp": "exp17",
+              "val_bpb": 1.087206,
+              "status": "discard"
+            },
+            {
+              "exp": "exp18",
+              "val_bpb": 1.077753,
+              "status": "discard"
+            },
+            {
+              "exp": "exp19",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp20",
+              "val_bpb": 1.09303,
+              "status": "discard"
+            },
+            {
+              "exp": "exp21",
+              "val_bpb": 1.112338,
+              "status": "discard"
+            },
+            {
+              "exp": "exp22",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp23",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp24",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp25",
+              "val_bpb": 1.093541,
+              "status": "discard"
+            },
+            {
+              "exp": "exp26",
+              "val_bpb": 1.136945,
+              "status": "discard"
+            },
+            {
+              "exp": "exp27",
+              "val_bpb": 1.083804,
+              "status": "discard"
+            },
+            {
+              "exp": "exp28",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp29",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp30",
+              "val_bpb": 1.084079,
+              "status": "discard"
+            },
+            {
+              "exp": "exp31",
+              "val_bpb": 1.087894,
+              "status": "discard"
+            },
+            {
+              "exp": "exp32",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp33",
+              "val_bpb": 1.075131,
+              "status": "discard"
+            },
+            {
+              "exp": "exp34",
+              "val_bpb": 1.084362,
+              "status": "discard"
+            },
+            {
+              "exp": "exp35",
+              "val_bpb": 1.209291,
+              "status": "discard"
+            },
+            {
+              "exp": "exp36",
+              "val_bpb": 1.120436,
+              "status": "discard"
+            },
+            {
+              "exp": "exp37",
+              "val_bpb": 1.073404,
+              "status": "discard"
+            },
+            {
+              "exp": "exp38",
+              "val_bpb": 1.144734,
+              "status": "discard"
+            },
+            {
+              "exp": "exp39",
+              "val_bpb": 1.09,
+              "status": "discard"
+            },
+            {
+              "exp": "exp40",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp41",
+              "val_bpb": 1.106942,
+              "status": "discard"
+            },
+            {
+              "exp": "exp42",
+              "val_bpb": 1.14076,
+              "status": "discard"
+            },
+            {
+              "exp": "exp43",
+              "val_bpb": 1.083153,
+              "status": "discard"
+            },
+            {
+              "exp": "exp44",
+              "val_bpb": 1.145432,
+              "status": "discard"
+            },
+            {
+              "exp": "exp45",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp46",
+              "val_bpb": 1.08665,
+              "status": "discard"
+            },
+            {
+              "exp": "exp47",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp48",
+              "val_bpb": 1.091623,
+              "status": "discard"
+            },
+            {
+              "exp": "exp49",
+              "val_bpb": 1.079878,
+              "status": "discard"
+            },
+            {
+              "exp": "exp50",
+              "val_bpb": 1.082911,
+              "status": "discard"
+            },
+            {
+              "exp": "exp51",
+              "val_bpb": 1.08914,
+              "status": "discard"
+            },
+            {
+              "exp": "exp52",
+              "val_bpb": 1.083364,
+              "status": "discard"
+            },
+            {
+              "exp": "exp53",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp54",
+              "val_bpb": 1.091472,
+              "status": "discard"
+            },
+            {
+              "exp": "exp55",
+              "val_bpb": 1.085726,
+              "status": "discard"
+            },
+            {
+              "exp": "exp56",
+              "val_bpb": 1.082595,
+              "status": "discard"
+            },
+            {
+              "exp": "exp57",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp58",
+              "val_bpb": 1.335104,
+              "status": "discard"
+            },
+            {
+              "exp": "exp59",
+              "val_bpb": 1.082677,
+              "status": "discard"
+            },
+            {
+              "exp": "exp60",
+              "val_bpb": 1.058682,
+              "status": "keep"
+            },
+            {
+              "exp": "exp61",
+              "val_bpb": 1.06145,
+              "status": "discard"
+            },
+            {
+              "exp": "exp62",
+              "val_bpb": 1.084675,
+              "status": "discard"
+            },
+            {
+              "exp": "exp63",
+              "val_bpb": 1.092761,
+              "status": "discard"
+            },
+            {
+              "exp": "exp64",
+              "val_bpb": 2.822764,
+              "status": "discard"
+            },
+            {
+              "exp": "exp65",
+              "val_bpb": 1.132095,
+              "status": "discard"
+            },
+            {
+              "exp": "exp66",
+              "val_bpb": 1.206528,
+              "status": "discard"
+            },
+            {
+              "exp": "exp67",
+              "val_bpb": 1.085946,
+              "status": "discard"
+            },
+            {
+              "exp": "exp68",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp69",
+              "val_bpb": 1.149303,
+              "status": "discard"
+            },
+            {
+              "exp": "exp70",
+              "val_bpb": 1.08832,
+              "status": "discard"
+            },
+            {
+              "exp": "exp71",
+              "val_bpb": 1.082765,
+              "status": "discard"
+            },
+            {
+              "exp": "exp72",
+              "val_bpb": 1.080724,
+              "status": "discard"
+            },
+            {
+              "exp": "exp73",
+              "val_bpb": 1.062803,
+              "status": "discard"
+            },
+            {
+              "exp": "exp74",
+              "val_bpb": 1.098751,
+              "status": "discard"
+            },
+            {
+              "exp": "exp75",
+              "val_bpb": 1.084892,
+              "status": "discard"
+            },
+            {
+              "exp": "exp76",
+              "val_bpb": 1.090477,
+              "status": "discard"
+            },
+            {
+              "exp": "exp77",
+              "val_bpb": 1.062834,
+              "status": "discard"
+            },
+            {
+              "exp": "exp78",
+              "val_bpb": 1.143079,
+              "status": "discard"
+            },
+            {
+              "exp": "exp79",
+              "val_bpb": 1.085846,
+              "status": "discard"
+            },
+            {
+              "exp": "exp80",
+              "val_bpb": 1.084867,
+              "status": "discard"
+            },
+            {
+              "exp": "exp81",
+              "val_bpb": 1.085483,
+              "status": "discard"
+            },
+            {
+              "exp": "exp82",
+              "val_bpb": 1.142858,
+              "status": "discard"
+            },
+            {
+              "exp": "exp83",
+              "val_bpb": 1.100048,
+              "status": "discard"
+            },
+            {
+              "exp": "exp84",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp85",
+              "val_bpb": 1.168823,
+              "status": "discard"
+            },
+            {
+              "exp": "exp86",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp87",
+              "val_bpb": 1.096577,
+              "status": "discard"
+            },
+            {
+              "exp": "exp88",
+              "val_bpb": 1.171037,
+              "status": "discard"
+            },
+            {
+              "exp": "exp89",
+              "val_bpb": 1.096999,
+              "status": "discard"
+            },
+            {
+              "exp": "exp90",
+              "val_bpb": 1.063359,
+              "status": "discard"
+            },
+            {
+              "exp": "exp91",
+              "val_bpb": 1.110836,
+              "status": "discard"
+            },
+            {
+              "exp": "exp92",
+              "val_bpb": 1.07331,
+              "status": "discard"
+            },
+            {
+              "exp": "exp93",
+              "val_bpb": 1.158634,
+              "status": "discard"
+            },
+            {
+              "exp": "exp94",
+              "val_bpb": 1.093284,
+              "status": "discard"
+            },
+            {
+              "exp": "exp95",
+              "val_bpb": 1.096605,
+              "status": "discard"
+            },
+            {
+              "exp": "exp96",
+              "val_bpb": 1.072476,
+              "status": "discard"
+            },
+            {
+              "exp": "exp97",
+              "val_bpb": 1.086375,
+              "status": "discard"
+            },
+            {
+              "exp": "exp98",
+              "val_bpb": 1.085449,
+              "status": "discard"
+            },
+            {
+              "exp": "exp99",
+              "val_bpb": 0.0,
+              "status": "crash"
+            }
+          ],
+          "kept_improvements": [
+            {
+              "exp": "exp1",
+              "val_bpb": 1.179595,
+              "description": "Add label smoothing to cross-entropy loss to improve generalization"
+            },
+            {
+              "exp": "exp3",
+              "val_bpb": 1.064721,
+              "description": "Reduce embedding initialization std from 1.0 to 0.02 for better generalization"
+            },
+            {
+              "exp": "exp60",
+              "val_bpb": 1.058682,
+              "description": "Reduce token embedding initialization std to 0.02 for better generalization"
+            }
+          ]
+        },
+        {
+          "file": "data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r3.tsv",
+          "dataset": "pubmed",
+          "model_slug": "gptoss120b",
+          "model": "GPT-OSS-120B",
+          "model_family": "OpenAI",
+          "contributor": "bmdhodl",
+          "gpu_slug": "rtx5070ti",
+          "gpu_name": "NVIDIA GeForce RTX 5070 Ti",
+          "total_exps": 99,
+          "keeps": 5,
+          "crashes": 12,
+          "discards": 82,
+          "skips": 0,
+          "keep_rate": 5.05050505050505,
+          "crash_rate": 12.121212121212121,
+          "best_bpb": 0.991808,
+          "baseline_bpb": 1.085763,
+          "bpb_trajectory": [
+            {
+              "exp": "exp0",
+              "val_bpb": 1.085763,
+              "status": "baseline"
+            },
+            {
+              "exp": "exp1",
+              "val_bpb": 1.113011,
+              "status": "discard"
+            },
+            {
+              "exp": "exp2",
+              "val_bpb": 1.092556,
+              "status": "discard"
+            },
+            {
+              "exp": "exp3",
+              "val_bpb": 1.109973,
+              "status": "discard"
+            },
+            {
+              "exp": "exp4",
+              "val_bpb": 1.078353,
+              "status": "keep"
+            },
+            {
+              "exp": "exp5",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp6",
+              "val_bpb": 1.091502,
+              "status": "discard"
+            },
+            {
+              "exp": "exp7",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp8",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp9",
+              "val_bpb": 1.090483,
+              "status": "discard"
+            },
+            {
+              "exp": "exp10",
+              "val_bpb": 1.210657,
+              "status": "discard"
+            },
+            {
+              "exp": "exp11",
+              "val_bpb": 1.086794,
+              "status": "discard"
+            },
+            {
+              "exp": "exp12",
+              "val_bpb": 1.112757,
+              "status": "discard"
+            },
+            {
+              "exp": "exp13",
+              "val_bpb": 1.07711,
+              "status": "keep"
+            },
+            {
+              "exp": "exp14",
+              "val_bpb": 1.216479,
+              "status": "discard"
+            },
+            {
+              "exp": "exp15",
+              "val_bpb": 1.104767,
+              "status": "discard"
+            },
+            {
+              "exp": "exp16",
+              "val_bpb": 1.090329,
+              "status": "discard"
+            },
+            {
+              "exp": "exp17",
+              "val_bpb": 1.083499,
+              "status": "discard"
+            },
+            {
+              "exp": "exp18",
+              "val_bpb": 1.082536,
+              "status": "discard"
+            },
+            {
+              "exp": "exp19",
+              "val_bpb": 1.282743,
+              "status": "discard"
+            },
+            {
+              "exp": "exp20",
+              "val_bpb": 1.085502,
+              "status": "discard"
+            },
+            {
+              "exp": "exp21",
+              "val_bpb": 1.090093,
+              "status": "discard"
+            },
+            {
+              "exp": "exp22",
+              "val_bpb": 1.086789,
+              "status": "discard"
+            },
+            {
+              "exp": "exp23",
+              "val_bpb": 1.076773,
+              "status": "keep"
+            },
+            {
+              "exp": "exp24",
+              "val_bpb": 1.096443,
+              "status": "discard"
+            },
+            {
+              "exp": "exp25",
+              "val_bpb": 1.08888,
+              "status": "discard"
+            },
+            {
+              "exp": "exp26",
+              "val_bpb": 1.11047,
+              "status": "discard"
+            },
+            {
+              "exp": "exp27",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp28",
+              "val_bpb": 1.086437,
+              "status": "discard"
+            },
+            {
+              "exp": "exp29",
+              "val_bpb": 1.084003,
+              "status": "discard"
+            },
+            {
+              "exp": "exp30",
+              "val_bpb": 1.092663,
+              "status": "discard"
+            },
+            {
+              "exp": "exp31",
+              "val_bpb": 1.096128,
+              "status": "discard"
+            },
+            {
+              "exp": "exp32",
+              "val_bpb": 1.076852,
+              "status": "discard"
+            },
+            {
+              "exp": "exp33",
+              "val_bpb": 1.153519,
+              "status": "discard"
+            },
+            {
+              "exp": "exp34",
+              "val_bpb": 1.082378,
+              "status": "discard"
+            },
+            {
+              "exp": "exp35",
+              "val_bpb": 0.992396,
+              "status": "keep"
+            },
+            {
+              "exp": "exp36",
+              "val_bpb": 0.998766,
+              "status": "discard"
+            },
+            {
+              "exp": "exp37",
+              "val_bpb": 1.088001,
+              "status": "discard"
+            },
+            {
+              "exp": "exp38",
+              "val_bpb": 1.107297,
+              "status": "discard"
+            },
+            {
+              "exp": "exp39",
+              "val_bpb": 1.094731,
+              "status": "discard"
+            },
+            {
+              "exp": "exp40",
+              "val_bpb": 1.109384,
+              "status": "discard"
+            },
+            {
+              "exp": "exp41",
+              "val_bpb": 1.116748,
+              "status": "discard"
+            },
+            {
+              "exp": "exp42",
+              "val_bpb": 1.061178,
+              "status": "discard"
+            },
+            {
+              "exp": "exp43",
+              "val_bpb": 1.092418,
+              "status": "discard"
+            },
+            {
+              "exp": "exp44",
+              "val_bpb": 1.10732,
+              "status": "discard"
+            },
+            {
+              "exp": "exp45",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp46",
+              "val_bpb": 1.087672,
+              "status": "discard"
+            },
+            {
+              "exp": "exp47",
+              "val_bpb": 1.138675,
+              "status": "discard"
+            },
+            {
+              "exp": "exp48",
+              "val_bpb": 1.088482,
+              "status": "discard"
+            },
+            {
+              "exp": "exp49",
+              "val_bpb": 1.084159,
+              "status": "discard"
+            },
+            {
+              "exp": "exp50",
+              "val_bpb": 1.083608,
+              "status": "discard"
+            },
+            {
+              "exp": "exp51",
+              "val_bpb": 1.066255,
+              "status": "discard"
+            },
+            {
+              "exp": "exp52",
+              "val_bpb": 1.086526,
+              "status": "discard"
+            },
+            {
+              "exp": "exp53",
+              "val_bpb": 1.095,
+              "status": "discard"
+            },
+            {
+              "exp": "exp54",
+              "val_bpb": 1.083986,
+              "status": "discard"
+            },
+            {
+              "exp": "exp55",
+              "val_bpb": 1.087125,
+              "status": "discard"
+            },
+            {
+              "exp": "exp56",
+              "val_bpb": 1.080953,
+              "status": "discard"
+            },
+            {
+              "exp": "exp57",
+              "val_bpb": 1.081734,
+              "status": "discard"
+            },
+            {
+              "exp": "exp58",
+              "val_bpb": 1.087108,
+              "status": "discard"
+            },
+            {
+              "exp": "exp59",
+              "val_bpb": 1.078586,
+              "status": "discard"
+            },
+            {
+              "exp": "exp60",
+              "val_bpb": 1.077778,
+              "status": "discard"
+            },
+            {
+              "exp": "exp61",
+              "val_bpb": 1.129527,
+              "status": "discard"
+            },
+            {
+              "exp": "exp62",
+              "val_bpb": 1.085324,
+              "status": "discard"
+            },
+            {
+              "exp": "exp63",
+              "val_bpb": 1.084072,
+              "status": "discard"
+            },
+            {
+              "exp": "exp64",
+              "val_bpb": 1.083171,
+              "status": "discard"
+            },
+            {
+              "exp": "exp65",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp66",
+              "val_bpb": 1.079083,
+              "status": "discard"
+            },
+            {
+              "exp": "exp67",
+              "val_bpb": 1.120822,
+              "status": "discard"
+            },
+            {
+              "exp": "exp68",
+              "val_bpb": 1.106532,
+              "status": "discard"
+            },
+            {
+              "exp": "exp69",
+              "val_bpb": 1.08717,
+              "status": "discard"
+            },
+            {
+              "exp": "exp70",
+              "val_bpb": 1.121343,
+              "status": "discard"
+            },
+            {
+              "exp": "exp71",
+              "val_bpb": 1.088194,
+              "status": "discard"
+            },
+            {
+              "exp": "exp72",
+              "val_bpb": 1.069875,
+              "status": "discard"
+            },
+            {
+              "exp": "exp73",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp74",
+              "val_bpb": 1.084256,
+              "status": "discard"
+            },
+            {
+              "exp": "exp75",
+              "val_bpb": 1.106846,
+              "status": "discard"
+            },
+            {
+              "exp": "exp76",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp77",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp78",
+              "val_bpb": 1.094065,
+              "status": "discard"
+            },
+            {
+              "exp": "exp79",
+              "val_bpb": 1.076748,
+              "status": "discard"
+            },
+            {
+              "exp": "exp80",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp81",
+              "val_bpb": 1.206338,
+              "status": "discard"
+            },
+            {
+              "exp": "exp82",
+              "val_bpb": 0.991808,
+              "status": "keep"
+            },
+            {
+              "exp": "exp83",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp84",
+              "val_bpb": 1.413419,
+              "status": "discard"
+            },
+            {
+              "exp": "exp85",
+              "val_bpb": 1.211807,
+              "status": "discard"
+            },
+            {
+              "exp": "exp86",
+              "val_bpb": 0.993419,
+              "status": "discard"
+            },
+            {
+              "exp": "exp87",
+              "val_bpb": 1.076733,
+              "status": "discard"
+            },
+            {
+              "exp": "exp88",
+              "val_bpb": 1.082897,
+              "status": "discard"
+            },
+            {
+              "exp": "exp89",
+              "val_bpb": 1.083666,
+              "status": "discard"
+            },
+            {
+              "exp": "exp90",
+              "val_bpb": 1.211362,
+              "status": "discard"
+            },
+            {
+              "exp": "exp91",
+              "val_bpb": 1.06202,
+              "status": "discard"
+            },
+            {
+              "exp": "exp92",
+              "val_bpb": 1.088426,
+              "status": "discard"
+            },
+            {
+              "exp": "exp93",
+              "val_bpb": 1.082817,
+              "status": "discard"
+            },
+            {
+              "exp": "exp94",
+              "val_bpb": 1.082073,
+              "status": "discard"
+            },
+            {
+              "exp": "exp95",
+              "val_bpb": 1.086932,
+              "status": "discard"
+            },
+            {
+              "exp": "exp96",
+              "val_bpb": 1.08534,
+              "status": "discard"
+            },
+            {
+              "exp": "exp97",
+              "val_bpb": 1.098193,
+              "status": "discard"
+            },
+            {
+              "exp": "exp98",
+              "val_bpb": 0.0,
+              "status": "crash"
+            },
+            {
+              "exp": "exp99",
+              "val_bpb": 1.362862,
+              "status": "discard"
+            }
+          ],
+          "kept_improvements": [
+            {
+              "exp": "exp4",
+              "val_bpb": 1.078353,
+              "description": "Increase weight decay on token embeddings and value embeddings to improve regularization"
+            },
+            {
+              "exp": "exp13",
+              "val_bpb": 1.07711,
+              "description": "Increase weight decay for token embeddings to improve regularization"
+            },
+            {
+              "exp": "exp23",
+              "val_bpb": 1.076773,
+              "description": "Set a non-zero final learning rate fraction to retain some learning rate at the end of training"
+            },
+            {
+              "exp": "exp35",
+              "val_bpb": 0.992396,
+              "description": "Reduce model size by decreasing ASPECT_RATIO to increase training throughput"
+            },
+            {
+              "exp": "exp82",
+              "val_bpb": 0.991808,
+              "description": "Reduce model dimension by lowering ASPECT_RATIO to 48, increasing training steps within the time budget"
+            }
+          ]
+        }
+      ],
+      "rank": 9
+    },
+    {
+      "dataset": "pubmed",
       "model": "GPT-4.1",
       "model_slug": "gpt41",
       "model_family": "OpenAI",
@@ -11318,7 +12984,7 @@
           ]
         }
       ],
-      "rank": 9
+      "rank": 10
     }
   ]
 }

--- a/scripts/build_benchmark.py
+++ b/scripts/build_benchmark.py
@@ -39,6 +39,7 @@ MODEL_NAMES = {
     "kimik25": "Kimi K2.5",
     "qwen35-397b": "Qwen 3.5 (397B)",
     "gemma4-31b": "Gemma 4 (31B)",
+    "gptoss120b": "GPT-OSS-120B",
 }
 
 # Map contributor handles to provider context where known


### PR DESCRIPTION
## Summary

Controlled comparison of **OpenAI's GPT-OSS-120B** -- OpenAI's first open-weight model (120B total params, 5.1B active via mixture-of-experts, Apache 2.0 license). Deployed via Azure AI Foundry.

- **n=3 runs x 100 experiments** each, identical frozen baseline (commit `3fb6704`, DEPTH=8, TOTAL_BATCH_SIZE=2^19)
- Hardware: NVIDIA GeForce RTX 5070 Ti (16GB, Blackwell SM 12.0)
- Dataset: PubMed medical abstracts
- 300 total experiments, all runs hit exactly 100 rows thanks to the while-loop + skip-logging fixes (PR #44, #45)

### Results

| | R1 | R2 | R3 | Mean +/- SD |
|---|---|---|---|---|
| Keeps | 7 | 3 | 5 | 5.0 +/- 2.0 |
| Keep rate | 7.1% | 3.0% | 5.1% | 5.1% +/- 2.0% |
| Crash rate | 9.1% | 18.2% | 12.1% | 13.1% +/- 4.6% |
| Best val_bpb | 1.066 | 1.059 | **0.992** | 1.039 +/- 0.041 |
| Baseline | 1.114 | 1.203 | 1.086 | 1.134 +/- 0.061 |

### Cross-model ranking (all n=3, RTX 5070 Ti, from frozen baseline)

| Model | Keep Rate | Crash Rate | Best val_bpb |
|-------|-----------|------------|-------------|
| Sonnet 4.6 | 13.1% +/- 5.0% | 23.5% +/- 1.5% | **0.9429 +/- 0.0025** |
| Kimi K2.5 | 12.2% +/- 6.1% | **8.8% +/- 2.5%** | 0.9788 +/- 0.0786 |
| GPT-OSS-120B | 5.1% +/- 2.0% | 13.1% +/- 4.6% | 1.0389 +/- 0.0410 |
| GPT-4.1 | 3.6% +/- 2.3% | 28.6% +/- 7.3% | 0.9836 +/- 0.0748 |

### Key findings

- **Lowest variance on keep rate** (SD=2.0 vs Kimi's 6.1 and Sonnet's 5.0). GPT-OSS-120B is predictable but underperforms.
- **R3 found the narrow-architecture strategy** (reduce ASPECT_RATIO to 48) that also worked for Kimi K2.5 R2, reaching 0.992 best val_bpb. R1 and R2 never tried it.
- **Path dependence similar to Kimi K2.5.** The reasoning chain-of-thought creates momentum toward whatever strategy the model starts with. R2 fixated on embedding initialization tweaks and only found 3 improvements.
- **Zero batch size attempts** across all 3 runs, matching Kimi's blind spot. Both reasoning-style models miss the highest-impact lever.
- **Reasoning model cost is minimal.** GPT-OSS-120B uses ~250 completion tokens per proposal (vs Kimi's ~9,000). Pricing is also cheap at \$0.15/\$0.60 per 1M tokens.

### Files
- `data/results/pubmed/bmdhodl-rtx5070ti/results_gptoss120b_r{1,2,3}.tsv` -- 14-column TSV, exactly 100 rows each
- `scripts/build_benchmark.py` -- added `gptoss120b` model slug (OpenAI provider)
- `docs/benchmark/data.json` -- rebuilt (GPT-OSS-120B at #9 on leaderboard with 3 runs)

## Test plan
- [x] All 3 TSVs have exactly 100 rows
- [x] Conversion script validated against existing data
- [x] Benchmark rebuilds successfully (10 entries, 23 total runs)
- [x] Full test suite passes (195/195)


🤖 Generated with [Claude Code](https://claude.com/claude-code)